### PR TITLE
Fix: change ClusterRole name to match what has been updated.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,8 @@ help: ## Display this help.
 ##@ Development
 
 .PHONY: manifests
-manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+manifests: controller-gen ## Generate ClusterRole objects.
+	$(CONTROLLER_GEN) rbac:roleName=odh-model-controller-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
 external-manifests: 
 	go get github.com/kserve/modelmesh-serving


### PR DESCRIPTION
**Description**:
Related to change made in RHODS-8873

Test without PR change:
>make manifestes

`config/rbac/role.yaml`
```
 - name: odh-model-controller-role
 + creationTimestamp: null
 + name: manager-role
```
Also remove unrelated object from comments
