### PR TITLE
add temporary initContainer and rbac to delete deprecated model-monit…

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,7 +32,34 @@ spec:
                 topologyKey: kubernetes.io/hostname
       securityContext:
         runAsNonRoot: true
-      containers:
+        runAsUser: 999
+      initContainers: 
+        - name: remove-deprecated-model-monitoring-stack
+          image: registry.redhat.io/openshift4/ose-cli@sha256:25fef269ac6e7491cb8340119a9b473acbeb53bc6970ad029fdaae59c3d0ca61
+          command: ["/bin/bash", "-c", "--"]
+          args:
+            - |
+              #delete prometheus operator deployment
+              prometheusoperatordeploymentexists=$(oc get deployments -o name -n redhat-ods-monitoring | grep rhods-prometheus-operator || echo "false")
+              if [[ $prometheusoperatordeploymentexists != "false" ]]; then
+                echo "deleting prometheus operator deployment for deprecated model monitoring stack"
+                oc delete deployment rhods-prometheus-operator -n redhat-ods-monitoring
+              fi 
+
+              #delete prometheus statefulset
+              prometheusstatefulsetexists=$(oc get statefulsets -o name -n redhat-ods-monitoring | grep prometheus-rhods-model-monitoring || echo "false")
+              if [[ $prometheusstatefulsetexists != "false" ]]; then
+                echo "deleting prometheus operator deployment for deprecated model monitoring stack"
+                oc delete statefulset prometheus-rhods-model-monitoring -n redhat-ods-monitoring
+              fi 
+
+              #delete servicemonitor
+              federatedmetricsservicemonitorexists=$(oc get servicemonitors -o name -n redhat-ods-monitoring | grep modelmesh-federated-metrics || echo "false")
+              if [[ $federatedmetricsservicemonitorexists != "false" ]]; then
+                echo "deleting prometheus operator deployment for deprecated model monitoring stack"
+                oc delete servicemonitor modelmesh-federated-metrics -n redhat-ods-monitoring
+              fi 
+      containers:        
         - command:
             - /manager
           args:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -22,6 +22,16 @@ rules:
   - patch
   - update
   - watch
+#revert before 2.7 https://issues.redhat.com/browse/RHOAIENG-293
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - delete
 - apiGroups:
   - maistra.io
   resources:


### PR DESCRIPTION
…oring stack


## Fixes: 
https://issues.redhat.com/browse/RHOAIENG-293 

## Context: 

The `model-monitoring` stack was deprecated in RHODS 2.5. This means that starting from 2.5, the RHODS Operator does not create the resources for `model-monitoring` during new installs. However, for upgrades from 2.4, the existing resources are not deleted. This PR adds a initContainer for RHODS 2.6 that deletes the resources from the `model-monitoring` stack that are no longer needed. 
Resources being deleted : 
- Deployment `rhods-prometheus-operator` 
- StatefulSet (containing 3 pods) `prometheus-rhods-model-monitoring` 
- ServiceMonitor `modelmesh-federated-metrics`

Note: This initContainer is a temporary addition for RHODS 2.6 ONLY, and will be reverted in 2.7 as it will not be needed anymore. 

## PR changes : 
- Added initContainer to odh-model-controller deployment to delete the resources mentioned above
- Added permissions to odh-model-controller-role to allow it the necessary privileges to perform the deletion
 
## Testing Instructions : 

#### Prerequisites 
- Install RHODS 2.4
- We install 2.4 because we want to test if the initContainer correctly deletes the resources created by the old monitoring stack. 
- I used RC3 build for 2.4 because I could not find a way to install the 2.4 version of the product from operatorhub. 
```
Catalog Source Images for 2.4 RC3 
Index image v4.11: registry-proxy.engineering.redhat.com/rh-osbs/iib:625499
Index image v4.12: registry-proxy.engineering.redhat.com/rh-osbs/iib:625502
Index image v4.13: registry-proxy.engineering.redhat.com/rh-osbs/iib:625517
Index image v4.14: registry-proxy.engineering.redhat.com/rh-osbs/iib:625527
Index image v4.15: registry-proxy.engineering.redhat.com/rh-osbs/iib:625532
``` 
[Instructions to install RC builds on clusters (doesn't work on ROSA):](https://docs.google.com/document/d/1DcnCV500nMrJFknWJXC6XAaylKlUY6XB4swltwiImKQ/edit#heading=h.uhu58j7scukc)   

#### Testing Steps
- Spin down RHODS Operator deployment to 0 in NS `redhat-ods-operator` 
   - We do this because we are testing the deletion of resources that are no longer watched by the operator starting from 2.5.0
   - For more context, the operator PR is [here](https://github.com/red-hat-data-services/rhods-operator/pull/151)
- Modify role `odh-model-controller-role` in NS `redhat-ods-applications` as per the rbac changes in PR 
   - Add `get`, `list`, `delete` permissions in apiGroup `apps` for resources `deployments`, `statefulsets` 
- Spin down `odh-model-controller` deployment from 3 -> 0 
- Modify yaml for `odh-model-controller` to add the `initContainer` lines as well as `securityContext.runAsUser: 999`
- Spin up `odh-model-controller` deployment from 0 -> 1 
- Watch logs for initContainer to verify no errors
- Manually verify the following resources no longer exist in the cluster in the NS `redhat-ods-monitoring`
   - Deployment `rhods-prometheus-operator`
   - Statefulset `prometheus-rhods-model-monitoring`
   - ServiceMonitor `modelmesh-federated-metrics` 
 
- Success! :) 
