### PR TITLE
[RHOAIENG-6877] - odh-model-controller breaks Knative if KServe-Serve…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,8 @@ help: ## Display this help.
 
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) rbac:roleName=odh-model-controller-role,headerFile="hack/manifests_boilerplate.yaml.txt" crd paths="./..." output:crd:artifacts:config=config/crd/bases
+	# Any customization needed, apply to the webhook_patch.yaml file
+	$(CONTROLLER_GEN) rbac:roleName=odh-model-controller-role,headerFile="hack/manifests_boilerplate.yaml.txt" crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
 external-manifests: 
 	go get github.com/kserve/modelmesh-serving

--- a/config/webhook/field_patch.yaml
+++ b/config/webhook/field_patch.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /metadata/name
+  value: validating.odh-model-controller.opendatahub.io

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -2,5 +2,21 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - manifests.yaml
-  - service.yaml
+- manifests.yaml
+- service.yaml
+
+
+patches:
+  - path: webhook_patch.yaml
+    target:
+      group: admissionregistration.k8s.io
+      kind: ValidatingWebhookConfiguration
+      name: validating-webhook-configuration
+      version: v1
+  - path: field_patch.yaml
+    target:
+      group: admissionregistration.k8s.io
+      kind: ValidatingWebhookConfiguration
+      name: validating-webhook-configuration
+      version: v1
+

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -2,15 +2,14 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: validating.odh-model-controller.opendatahub.io
-  annotations:
-    service.beta.openshift.io/inject-cabundle: true
+  name: validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:
   - v1
   clientConfig:
     service:
-      name: odh-model-controller-webhook-service
+      name: webhook-service
+      namespace: system
       path: /validate-serving-knative-dev-v1-service
   failurePolicy: Fail
   name: validating.ksvc.odh-model-controller.opendatahub.io

--- a/config/webhook/webhook_patch.yaml
+++ b/config/webhook/webhook_patch.yaml
@@ -1,0 +1,16 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating.odh-model-controller.opendatahub.io
+  annotations:
+    service.beta.openshift.io/inject-cabundle: true
+webhooks:
+  - name: validating.ksvc.odh-model-controller.opendatahub.io
+    clientConfig:
+      service:
+        name: odh-model-controller-webhook-service
+    objectSelector:
+      matchExpressions:
+        - key: serving.kserve.io/inferenceservice
+          operator: Exists
+


### PR DESCRIPTION
…rless is not enabled

chore:	Make the validating.odh-model-controller.opendatahub.io intercept only ksvc that
	contains the serving.kserve.io/inferenceservice label. This label is added by KServe
	to any ksvc handled by it, this way we avoid other OpenShift Serverless user not be
	affected by this webhook in case it is not started by odh-model-controller.


Cherry-picks https://github.com/opendatahub-io/odh-model-controller/pull/203