### PR TITLE
Fix: update params.env to match upstream equivalent

### DIFF
--- a/config/base/params.env
+++ b/config/base/params.env
@@ -1,5 +1,6 @@
 odh-model-controller=quay.io/opendatahub/odh-model-controller:v0.12.0-latest
 caikit-tgis-image=quay.io/opendatahub/caikit-tgis-serving:stable-01d6d99
+caikit-standalone-image=quay.io/modh/caikit-nlp@sha256:73273d06bbcaf479122bea90159369337d3af0715bd01664d5499805623bf871
 tgis-image=quay.io/opendatahub/text-generation-inference:stable-ed9d828
 ovms-image=quay.io/opendatahub/openvino_model_server:stable-nightly-2024-05-26
 vllm-image=quay.io/opendatahub/vllm:stable-affc486


### PR DESCRIPTION
Updates `config/base/params.env` to match [opendatahub-io#218](https://github.com/opendatahub-io/odh-model-controller/pull/218) by adding the Caikit Standalone image.
