### PR TITLE
Fix vLLM references image SHA

### DIFF
--- a/config/base/params.env
+++ b/config/base/params.env
@@ -3,4 +3,4 @@ caikit-tgis-image=quay.io/modh/caikit-tgis-serving@sha256:4e907ce35a3767f5be2f31
 caikit-standalone-image=quay.io/modh/caikit-nlp@sha256:0cde6c26e02ec398aea959a1a1bcdc615b86821adb41989e81d03de01124545c
 tgis-image=quay.io/modh/text-generation-inference@sha256:294f07b2a94a223a18e559d497a79cac53bf7893f36cfc6c995475b6e431bcfe
 ovms-image=quay.io/modh/openvino_model_server@sha256:9ccb29967f39b5003cf395cc686a443d288869578db15d0d37ed8ebbeba19375
-vllm-image=quay.io/modh/vllm@sha256:23425b36194ec2a704c094a222735498b95c8eafbfe76e511b20c0112da6c542
+vllm-image=quay.io/modh/vllm@sha256:a43f7f6e339cce63442020217fdf9201f296e498251a6bf0b5c0d2294ba8c8b5


### PR DESCRIPTION
**Analysis**
We noticed that the vLLM tag `sha256:23425b36194ec2a704c094a222735498b95c8eafbfe76e511b20c0112da6c542`  was missing from `quay.io/modh/vllm`. Looking at the logs for Openshift CI, we noticed that a build was re-triggered on the vLLM `rhoai-2.11` branch on June 24th, causing the old image tag to be deleted.

Here are the openshift CI logs for the `rhoai-2.11` branch:
```
1805288431018840064		 Jun 24 19:14:41 58m9s	SUCCESS
1804221778231300096		Jun 21 20:36:12 1h4m5s	SUCCESS
1804207384537600000		Jun 21 19:39:00 57m5s	SUCCESS 
```
see: https://prow.ci.openshift.org/job-history/gs/test-platform-results/logs/branch-ci-red-hat-data-services-vllm-rhoai-2.11-images for more details.

**Solution**
Create this PR to update the new image reference