### PR TITLE
Upgrade OVMS image SHA

### DIFF
--- a/config/base/params.env
+++ b/config/base/params.env
@@ -2,5 +2,5 @@ odh-model-controller=quay.io/opendatahub/odh-model-controller:v0.12.0
 caikit-tgis-image=quay.io/modh/caikit-tgis-serving@sha256:24c5e0ee02473aa70275692e8b11f0fcc35caaab33b19a447f920877cc704bac
 caikit-standalone-image=quay.io/modh/caikit-nlp@sha256:37a78ca02dd89fc8dd942d8d731fbd37a4caaad48f4d13e90bb610590743a0a6
 tgis-image=quay.io/modh/text-generation-inference@sha256:b4ad37ef082d2e417fc5ec52014c06c5ecaaad082eb6d0ecdced5bc305fbae49
-ovms-image=quay.io/opendatahub/openvino_model_server:stable-nightly-2024-05-26
+ovms-image=quay.io/modh/openvino_model_server@sha256:9ccb29967f39b5003cf395cc686a443d288869578db15d0d37ed8ebbeba19375
 vllm-image=quay.io/modh/vllm@sha256:54bc037a5ea8f29b44674d496cbf58fab76a622bc47be030b32afcb735f98a38


### PR DESCRIPTION
OVMS build for RHOAI-2.12 is failing so we are reverting it to point RHOAI-2.11