### PR TITLE
Update TGIS image for 2.16.1

### DIFF
--- a/config/base/params.env
+++ b/config/base/params.env
@@ -1,6 +1,6 @@
 odh-model-controller=quay.io/opendatahub/odh-model-controller:v0.12.0
 caikit-tgis-image=quay.io/modh/caikit-tgis-serving@sha256:fe0d1f1233d0b056ca7c690f765b20611e20837465674998e3d293df9b95e838
 caikit-standalone-image=quay.io/modh/caikit-nlp@sha256:3c33185fda84d7bac6715c8743c446a6713cdbc0cb0ed831acc0df89bd8bab6b
-tgis-image=quay.io/modh/text-generation-inference@sha256:bb36bb41cc744a8ff94d537f74c228e8b4e17c2468c50ccd89fc21ecc3940a70
+tgis-image=quay.io/modh/text-generation-inference@sha256:107a92426de8a1db544ffd0777044b11625d375d278a42baaa28eba1f14dfd18
 ovms-image=quay.io/modh/openvino_model_server@sha256:f1140e9d987580d1aab1ccc62519b48b1d2673308b2db496e9e505e3be788d9f
 vllm-image=quay.io/modh/vllm@sha256:c86ff1e89c86bc9821b75d7f2bbc170b3c13e3ccf538bf543b1110f23e056316


### PR DESCRIPTION
UBI 9.4 shows at least one or more high/important [CVEs](https://quay.io/repository/modh/text-generation-inference/manifest/sha256:bb36bb41cc744a8ff94d537f74c228e8b4e17c2468c50ccd89fc21ecc3940a70?tab=vulnerabilities). 
UBI 9.5 has those vulnerabilities resolved.

Updated UBI to 9.5 and now updating the TGIS image to latest one for 2.16.1 release.

Resolves https://issues.redhat.com/browse/RHOAIENG-16987 