### PR TITLE
Update component_metadata and add vllm gaudi

### DIFF
--- a/config/component_metadata.yaml
+++ b/config/component_metadata.yaml
@@ -6,7 +6,7 @@ releases:
     version: v0.12.0
     repoUrl: https://github.com/kserve/modelmesh-serving
   - name: vLLM
-    version: v0.6.4.post1
+    version: v0.6.6.post1
     repoUrl: https://github.com/vllm-project/vllm
   - name: OpenVINO Model Server
     version: v2024.5
@@ -15,8 +15,11 @@ releases:
     version: v0.27.7
     repoUrl: https://github.com/caikit/caikit
   - name: Caikit-nlp
-    version: v0.5.8
+    version: v0.5.9
     repoUrl: https://github.com/caikit/caikit-nlp
   - name: Text Generation Inference Server
-    version: commit 8a8c55dd0884b8e4e420d22f10bcce6752455edf
+    version: commit 56d8aafb9727b7dd27aaeb440dbddef061f72a9f
     repoUrl: https://github.com/IBM/text-generation-inference/
+  - name: vLLM Gaudi
+    version: v0.6.4.post2+Gaudi-1.19.0
+    repoUrl: https://github.com/HabanaAI/vllm-fork


### PR DESCRIPTION
Updated versions in component_metadata for 2.17 release and added vLLM Gaudi information there.