### PR TITLE
chore: backporting nim integration fixes

### DIFF
--- a/controllers/nim_account_controller.go
+++ b/controllers/nim_account_controller.go
@@ -185,7 +185,7 @@ func (r *NimAccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	meta.SetStatusCondition(&targetStatus.Conditions, makeAccountFailureCondition(account.Generation, runtimesOk))
 
 	// validate api key
-	if err := utils.ValidateApiKey(logger, apiKeyStr, availableRuntimes[0]); err != nil {
+	if err := utils.ValidateApiKey(logger, apiKeyStr, availableRuntimes); err != nil {
 		msg := "api key failed validation"
 		logger.Error(err, msg)
 		meta.SetStatusCondition(&targetStatus.Conditions, makeAccountFailureCondition(account.Generation, msg))

--- a/controllers/nim_account_controller.go
+++ b/controllers/nim_account_controller.go
@@ -61,6 +61,10 @@ var (
 )
 
 func (r *NimAccountReconciler) SetupWithManager(mgr ctrl.Manager, ctx context.Context) error {
+	// TODO: Copied from original main.go... Should it be FromContext?
+	logger := ctrl.Log.WithName("controllers").WithName("AccountControllerSetup")
+	log.IntoContext(ctx, logger)
+
 	if err := mgr.GetFieldIndexer().IndexField(ctx, &v1.Account{}, apiKeySpecPath, func(obj client.Object) []string {
 		return []string{obj.(*v1.Account).Spec.APIKeySecret.Name}
 	}); err != nil {
@@ -168,7 +172,7 @@ func (r *NimAccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	meta.SetStatusCondition(&targetStatus.Conditions, makeAccountFailureCondition(account.Generation, gotApiKey))
 
 	// fetch available runtimes
-	availableRuntimes, runtimesErr := utils.GetAvailableNimRuntimes()
+	availableRuntimes, runtimesErr := utils.GetAvailableNimRuntimes(logger)
 	if runtimesErr != nil {
 		msg := "failed to fetch NIM available custom runtimes"
 		logger.V(1).Error(runtimesErr, msg)
@@ -181,7 +185,7 @@ func (r *NimAccountReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	meta.SetStatusCondition(&targetStatus.Conditions, makeAccountFailureCondition(account.Generation, runtimesOk))
 
 	// validate api key
-	if err := utils.ValidateApiKey(apiKeyStr, availableRuntimes[0]); err != nil {
+	if err := utils.ValidateApiKey(logger, apiKeyStr, availableRuntimes[0]); err != nil {
 		msg := "api key failed validation"
 		logger.Error(err, msg)
 		meta.SetStatusCondition(&targetStatus.Conditions, makeAccountFailureCondition(account.Generation, msg))
@@ -261,7 +265,7 @@ func (r *NimAccountReconciler) reconcileNimConfig(
 	ctx context.Context, ownerCfg *ssametav1.OwnerReferenceApplyConfiguration,
 	namespace, apiKey string, runtimes []utils.NimRuntime,
 ) (*corev1.ConfigMap, error) {
-	data, dErr := utils.GetNimModelData(apiKey, runtimes)
+	data, dErr := utils.GetNimModelData(log.FromContext(ctx), apiKey, runtimes)
 	if dErr != nil {
 		return nil, dErr
 	}

--- a/controllers/nim_account_controller_test.go
+++ b/controllers/nim_account_controller_test.go
@@ -74,6 +74,9 @@ var _ = Describe("NIM Account Controller Test Cases", func() {
 		Expect(cli.Get(ctx, pullSecretSubject, pullSecret)).To(Succeed())
 		Expect(pullSecret.OwnerReferences[0]).To(Equal(expectedOwner))
 
+		By("Verify models info")
+		Expect(dataCmap.Data).To(HaveLen(2))
+
 		By("Cleanups")
 		apiKeySecret := &corev1.Secret{}
 		apiKeySubject := namespacedNameFromReference(&account.Spec.APIKeySecret)

--- a/controllers/nim_account_controller_test.go
+++ b/controllers/nim_account_controller_test.go
@@ -74,7 +74,7 @@ var _ = Describe("NIM Account Controller Test Cases", func() {
 		Expect(cli.Get(ctx, pullSecretSubject, pullSecret)).To(Succeed())
 		Expect(pullSecret.OwnerReferences[0]).To(Equal(expectedOwner))
 
-		By("Verify models info")
+		By("Verify only two models (the nemotron model fetch is not stubbed)")
 		Expect(dataCmap.Data).To(HaveLen(2))
 
 		By("Cleanups")

--- a/controllers/testdata/nim/ngc_catalog_response_page_0.json
+++ b/controllers/testdata/nim/ngc_catalog_response_page_0.json
@@ -1,5 +1,5 @@
 {
-  "resultTotal": 2,
+  "resultTotal": 3,
   "resultPageTotal": 2,
   "params": {
     "orderBy": [
@@ -17,7 +17,7 @@
       "description"
     ],
     "scoredSize": 1,
-    "pageSize": 1,
+    "pageSize": 2,
     "fields": [
       "weight_popular",
       "ace_name",
@@ -150,7 +150,7 @@
       ]
     },
     {
-      "totalCount": 2,
+      "totalCount": 3,
       "groupValue": "CONTAINER",
       "resources": [
         {
@@ -229,6 +229,88 @@
             {
               "key": "logo",
               "value": "https://assets.ngc.nvidia.com/products/api-catalog/images/phi-3-mini-4k-instruct.jpg"
+            }
+          ]
+        },
+        {
+          "orgName": "nim",
+          "resourceId": "nim/nvidia/nemotron-4-340b-instruct",
+          "labels": [
+            {
+              "values": [
+                "NVIDIA AI Enterprise Supported",
+                "NIM",
+                "NSPECT-0BKP-31SV",
+                "Nemotron-4-340B-Instruct",
+                "NVIDIA NIM"
+              ],
+              "key": "general"
+            },
+            {
+              "values": [
+                "signed images"
+              ],
+              "key": "system"
+            },
+            {
+              "values": [
+                "true"
+              ],
+              "key": "hasSignedTag"
+            },
+            {
+              "values": [
+                "NVIDIA"
+              ],
+              "key": "publisher"
+            },
+            {
+              "values": [
+                "nim-dev",
+                "nv-ai-enterprise"
+              ],
+              "key": "productNames"
+            }
+          ],
+          "sharedWithTeams": [
+            "nim/nvidia"
+          ],
+          "teamName": "nvidia",
+          "msgTimestamp": 1724956384091,
+          "dateModified": "2024-08-29T18:33:02.979Z",
+          "sharedWithOrgs": [],
+          "description": "NVIDIA NIM for GPU accelerated Nemotron-4-340B-Instruct inference through OpenAI compatible APIs",
+          "accessType": "LISTED",
+          "dateCreated": "2024-08-28T22:50:58.702Z",
+          "weightPopular": 3275.6,
+          "createdBy": "ump9hejl7s8kt8foag1jokg1ia",
+          "displayName": "nemotron-4-340b-instruct",
+          "name": "nemotron-4-340b-instruct",
+          "resourceType": "CONTAINER",
+          "attributes": [
+            {
+              "key": "latestTag",
+              "value": "1.1.2"
+            },
+            {
+              "key": "size",
+              "value": "6729257602"
+            },
+            {
+              "key": "hasSignedTag",
+              "value": "true"
+            },
+            {
+              "key": "oneClickDeploy",
+              "value": "false"
+            },
+            {
+              "key": "latestTagPushedDate",
+              "value": "2024-08-29T18:32:52.864Z"
+            },
+            {
+              "key": "logo",
+              "value": "https://assets.ngc.nvidia.com/products/api-catalog/images/nemotron-4-340b-instruct.jpg"
             }
           ]
         }

--- a/controllers/testdata/nim/ngc_catalog_response_page_0.json
+++ b/controllers/testdata/nim/ngc_catalog_response_page_0.json
@@ -1,0 +1,238 @@
+{
+  "resultTotal": 2,
+  "resultPageTotal": 2,
+  "params": {
+    "orderBy": [
+      {
+        "field": "score",
+        "value": "DESC"
+      }
+    ],
+    "queryFields": [
+      "name",
+      "displayName",
+      "all",
+      "publisher",
+      "builtBy",
+      "description"
+    ],
+    "scoredSize": 1,
+    "pageSize": 1,
+    "fields": [
+      "weight_popular",
+      "ace_name",
+      "date_created",
+      "resource_type",
+      "description",
+      "display_name",
+      "created_by",
+      "weight_featured",
+      "team_name",
+      "labels",
+      "shared_with_orgs",
+      "date_modified",
+      "shared_with_teams",
+      "is_public",
+      "name",
+      "resource_id",
+      "attributes",
+      "org_name",
+      "guest_access",
+      "msg_timestamp",
+      "status"
+    ],
+    "page": 0,
+    "filters": [
+      {
+        "field": "orgName",
+        "value": "nim"
+      },
+      {
+        "field": "resourceType",
+        "value": "container"
+      },
+      {
+        "field": "accessType",
+        "value": "LISTED"
+      },
+      {
+        "field": "isPublic",
+        "value": "true"
+      }
+    ],
+    "query": "*:*",
+    "groupBy": "resourceType"
+  },
+  "results": [
+    {
+      "totalCount": 1,
+      "groupValue": "_scored",
+      "resources": [
+        {
+          "orgName": "nim",
+          "resourceId": "nim/microsoft/phi-3-mini-4k-instruct",
+          "labels": [
+            {
+              "values": [
+                "NSPECT-Y9G4-II8Q",
+                "NVIDIA AI Enterprise Supported",
+                "NVIDIA NIM"
+              ],
+              "key": "general"
+            },
+            {
+              "values": [
+                "signed images"
+              ],
+              "key": "system"
+            },
+            {
+              "values": [
+                "true"
+              ],
+              "key": "hasSignedTag"
+            },
+            {
+              "values": [
+                "NVIDIA"
+              ],
+              "key": "publisher"
+            },
+            {
+              "values": [
+                "nv-ai-enterprise",
+                "nim-dev"
+              ],
+              "key": "productNames"
+            }
+          ],
+          "sharedWithTeams": [
+            "nim/microsoft"
+          ],
+          "teamName": "microsoft",
+          "msgTimestamp": 1729620896993,
+          "dateModified": "2024-10-22T18:14:56.808Z",
+          "sharedWithOrgs": [],
+          "description": "NVIDIA NIM for GPU supported Phi-3-Mini-4K-Instruct inference through OpenAI compatible APIs",
+          "dateCreated": "2024-10-18T04:04:45.314Z",
+          "weightPopular": 249.5,
+          "createdBy": "ump9hejl7s8kt8foag1jokg1ia",
+          "displayName": "Phi-3-Mini-4K-Instruct",
+          "name": "phi-3-mini-4k-instruct",
+          "resourceType": "CONTAINER",
+          "attributes": [
+            {
+              "key": "latestTag",
+              "value": "1.2.3"
+            },
+            {
+              "key": "size",
+              "value": "6835134649"
+            },
+            {
+              "key": "hasSignedTag",
+              "value": "true"
+            },
+            {
+              "key": "oneClickDeploy",
+              "value": "false"
+            },
+            {
+              "key": "latestTagPushedDate",
+              "value": "2024-10-18T04:07:55.199Z"
+            },
+            {
+              "key": "logo",
+              "value": "https://assets.ngc.nvidia.com/products/api-catalog/images/phi-3-mini-4k-instruct.jpg"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "totalCount": 2,
+      "groupValue": "CONTAINER",
+      "resources": [
+        {
+          "orgName": "nim",
+          "resourceId": "nim/microsoft/phi-3-mini-4k-instruct",
+          "labels": [
+            {
+              "values": [
+                "NSPECT-Y9G4-II8Q",
+                "NVIDIA AI Enterprise Supported",
+                "NVIDIA NIM"
+              ],
+              "key": "general"
+            },
+            {
+              "values": [
+                "signed images"
+              ],
+              "key": "system"
+            },
+            {
+              "values": [
+                "true"
+              ],
+              "key": "hasSignedTag"
+            },
+            {
+              "values": [
+                "NVIDIA"
+              ],
+              "key": "publisher"
+            },
+            {
+              "values": [
+                "nv-ai-enterprise",
+                "nim-dev"
+              ],
+              "key": "productNames"
+            }
+          ],
+          "sharedWithTeams": [
+            "nim/microsoft"
+          ],
+          "teamName": "microsoft",
+          "msgTimestamp": 1729620896993,
+          "dateModified": "2024-10-22T18:14:56.808Z",
+          "sharedWithOrgs": [],
+          "description": "NVIDIA NIM for GPU supported Phi-3-Mini-4K-Instruct inference through OpenAI compatible APIs",
+          "dateCreated": "2024-10-18T04:04:45.314Z",
+          "weightPopular": 249.5,
+          "createdBy": "ump9hejl7s8kt8foag1jokg1ia",
+          "displayName": "Phi-3-Mini-4K-Instruct",
+          "name": "phi-3-mini-4k-instruct",
+          "resourceType": "CONTAINER",
+          "attributes": [
+            {
+              "key": "latestTag",
+              "value": "1.2.3"
+            },
+            {
+              "key": "size",
+              "value": "6835134649"
+            },
+            {
+              "key": "hasSignedTag",
+              "value": "true"
+            },
+            {
+              "key": "oneClickDeploy",
+              "value": "false"
+            },
+            {
+              "key": "latestTagPushedDate",
+              "value": "2024-10-18T04:07:55.199Z"
+            },
+            {
+              "key": "logo",
+              "value": "https://assets.ngc.nvidia.com/products/api-catalog/images/phi-3-mini-4k-instruct.jpg"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/controllers/testdata/nim/ngc_catalog_response_page_1.json
+++ b/controllers/testdata/nim/ngc_catalog_response_page_1.json
@@ -1,5 +1,5 @@
 {
-  "resultTotal": 2,
+  "resultTotal": 3,
   "resultPageTotal": 2,
   "params": {
     "orderBy": [

--- a/controllers/testdata/nim/ngc_catalog_response_page_1.json
+++ b/controllers/testdata/nim/ngc_catalog_response_page_1.json
@@ -1,6 +1,6 @@
 {
   "resultTotal": 2,
-  "resultPageTotal": 1,
+  "resultPageTotal": 2,
   "params": {
     "orderBy": [
       {
@@ -41,7 +41,7 @@
       "msg_timestamp",
       "status"
     ],
-    "page": 0,
+    "page": 1,
     "filters": [
       {
         "field": "orgName",
@@ -153,85 +153,6 @@
       "totalCount": 2,
       "groupValue": "CONTAINER",
       "resources": [
-        {
-          "orgName": "nim",
-          "resourceId": "nim/microsoft/phi-3-mini-4k-instruct",
-          "labels": [
-            {
-              "values": [
-                "NSPECT-Y9G4-II8Q",
-                "NVIDIA AI Enterprise Supported",
-                "NVIDIA NIM"
-              ],
-              "key": "general"
-            },
-            {
-              "values": [
-                "signed images"
-              ],
-              "key": "system"
-            },
-            {
-              "values": [
-                "true"
-              ],
-              "key": "hasSignedTag"
-            },
-            {
-              "values": [
-                "NVIDIA"
-              ],
-              "key": "publisher"
-            },
-            {
-              "values": [
-                "nv-ai-enterprise",
-                "nim-dev"
-              ],
-              "key": "productNames"
-            }
-          ],
-          "sharedWithTeams": [
-            "nim/microsoft"
-          ],
-          "teamName": "microsoft",
-          "msgTimestamp": 1729620896993,
-          "dateModified": "2024-10-22T18:14:56.808Z",
-          "sharedWithOrgs": [],
-          "description": "NVIDIA NIM for GPU supported Phi-3-Mini-4K-Instruct inference through OpenAI compatible APIs",
-          "dateCreated": "2024-10-18T04:04:45.314Z",
-          "weightPopular": 249.5,
-          "createdBy": "ump9hejl7s8kt8foag1jokg1ia",
-          "displayName": "Phi-3-Mini-4K-Instruct",
-          "name": "phi-3-mini-4k-instruct",
-          "resourceType": "CONTAINER",
-          "attributes": [
-            {
-              "key": "latestTag",
-              "value": "1.2.3"
-            },
-            {
-              "key": "size",
-              "value": "6835134649"
-            },
-            {
-              "key": "hasSignedTag",
-              "value": "true"
-            },
-            {
-              "key": "oneClickDeploy",
-              "value": "false"
-            },
-            {
-              "key": "latestTagPushedDate",
-              "value": "2024-10-18T04:07:55.199Z"
-            },
-            {
-              "key": "logo",
-              "value": "https://assets.ngc.nvidia.com/products/api-catalog/images/phi-3-mini-4k-instruct.jpg"
-            }
-          ]
-        },
         {
           "orgName": "nim",
           "resourceId": "nim/meta/llama-3.1-8b-instruct",

--- a/controllers/testdata/nvidia_api_mock.go
+++ b/controllers/testdata/nvidia_api_mock.go
@@ -20,6 +20,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"github.com/opendatahub-io/odh-model-controller/controllers/utils"
 	"io"
 	"net/http"
@@ -40,7 +41,7 @@ func (r *NimHttpClientMock) Do(req *http.Request) (*http.Response, error) {
 		catParams := &utils.NimCatalogQuery{}
 		_ = json.Unmarshal([]byte(req.URL.Query().Get("q")), catParams)
 		if catParams.Query == "orgName:nim" {
-			f, _ := os.ReadFile("testdata/nim/ngc_catalog_response.json")
+			f, _ := os.ReadFile(fmt.Sprintf("testdata/nim/ngc_catalog_response_page_%d.json", catParams.Page))
 			return &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader(f))}, nil
 		}
 	}
@@ -50,7 +51,7 @@ func (r *NimHttpClientMock) Do(req *http.Request) (*http.Response, error) {
 		if req.URL.Query().Get("account") == "$oauthtoken" && req.URL.Query().Get("offline_token") == "true" {
 			if req.URL.Query().Get("scope") == "repository:nim/microsoft/phi-3-mini-4k-instruct:pull" {
 				// repository name "nim/microsoft/phi-3-mini-4k-instruct" is the FIRST resource from the available
-				// from runtimes returned by the ngc catalog endpoint, check testdata/nim/ngc_catalog_response.json
+				// from runtimes returned by the ngc catalog endpoint, check testdata/nim/ngc_catalog_response_page_0.json
 				authHeaderParts := strings.Split(req.Header.Get("Authorization"), " ")
 				token, _ := base64.StdEncoding.DecodeString(authHeaderParts[1])
 				if authHeaderParts[0] == "Basic" && string(token) == "$oauthtoken:"+FakeApiKey {
@@ -65,7 +66,7 @@ func (r *NimHttpClientMock) Do(req *http.Request) (*http.Response, error) {
 	if req.URL.Host == "nvcr.io" && req.URL.Path == "/v2/nim/microsoft/phi-3-mini-4k-instruct/manifests/1.2.3" {
 		// repository name "nim/microsoft/phi-3-mini-4k-instruct" is the FIRST resource from the available
 		// from runtimes returned by the ngc catalog endpoint, version "1.2.3" is the latestTag attribute for the runtime
-		// check testdata/nim/ngc_catalog_response.json
+		// check testdata/nim/ngc_catalog_response_page_0.json
 		authHeaderParts := strings.Split(req.Header.Get("Authorization"), " ")
 		if authHeaderParts[0] == "Bearer" && authHeaderParts[1] == "this-is-my-fake-token-please-dont-share-it-with-anyone" {
 			if req.Header.Get("Accept") == "application/vnd.oci.image.index.v1+json" {
@@ -87,7 +88,7 @@ func (r *NimHttpClientMock) Do(req *http.Request) (*http.Response, error) {
 	// stub model info for the FIRST model we stub, requested by utils.GetNimModelData (nim)
 	if req.URL.Host == "api.ngc.nvidia.com" && req.URL.Path == "/v2/org/nim/team/microsoft/repos/phi-3-mini-4k-instruct" {
 		// repository name "nim/microsoft/phi-3-mini-4k-instruct" is the FIRST resource from the available
-		// from runtimes returned by the ngc catalog endpoint, check testdata/nim/ngc_catalog_response.json
+		// from runtimes returned by the ngc catalog endpoint, check testdata/nim/ngc_catalog_response_page_0.json
 		authHeaderParts := strings.Split(req.Header.Get("Authorization"), " ")
 		if authHeaderParts[0] == "Bearer" && authHeaderParts[1] == "this-is-yet-another-fake-token-of-mine-you-know-what-not-do-to" {
 			// the token is returned by the authn.nvidia.com/token endpoint (stubbed), check testdata/nim/ngc_token_response.json
@@ -99,7 +100,7 @@ func (r *NimHttpClientMock) Do(req *http.Request) (*http.Response, error) {
 	// stub model info for the SECOND model we stub, requested by utils.GetNimModelData (nim)
 	if req.URL.Host == "api.ngc.nvidia.com" && req.URL.Path == "/v2/org/nim/team/meta/repos/llama-3.1-8b-instruct" {
 		// repository name "nim/meta/llama-3.1-8b-instruct" is the SECOND resource from the available
-		// from runtimes returned by the ngc catalog endpoint, check testdata/nim/ngc_catalog_response.json
+		// from runtimes returned by the ngc catalog endpoint, check testdata/nim/ngc_catalog_response_page_1.json
 		authHeaderParts := strings.Split(req.Header.Get("Authorization"), " ")
 		if authHeaderParts[0] == "Bearer" && authHeaderParts[1] == "this-is-yet-another-fake-token-of-mine-you-know-what-not-do-to" {
 			// the token is returned by the authn.nvidia.com/token endpoint (stubbed), check testdata/nim/ngc_token_response.json

--- a/controllers/testdata/nvidia_api_mock.go
+++ b/controllers/testdata/nvidia_api_mock.go
@@ -68,8 +68,10 @@ func (r *NimHttpClientMock) Do(req *http.Request) (*http.Response, error) {
 		// check testdata/nim/ngc_catalog_response.json
 		authHeaderParts := strings.Split(req.Header.Get("Authorization"), " ")
 		if authHeaderParts[0] == "Bearer" && authHeaderParts[1] == "this-is-my-fake-token-please-dont-share-it-with-anyone" {
-			// the token is returned by the nvcr.io/proxy-auth endpoint (stubbed), check testdata/nim/runtime_token_response.json
-			return &http.Response{StatusCode: 200}, nil
+			if req.Header.Get("Accept") == "application/vnd.oci.image.index.v1+json" {
+				// the token is returned by the nvcr.io/proxy-auth endpoint (stubbed), check testdata/runtime_token_response.json
+				return &http.Response{StatusCode: 200}, nil
+			}
 		}
 	}
 

--- a/controllers/utils/nim.go
+++ b/controllers/utils/nim.go
@@ -305,6 +305,11 @@ func GetNimServingRuntimeTemplate(scheme *runtime.Scheme) (*v1alpha1.ServingRunt
 		},
 		Spec: v1alpha1.ServingRuntimeSpec{
 			ServingRuntimePodSpec: v1alpha1.ServingRuntimePodSpec{
+				Annotations: map[string]string{
+					"prometheus.io/path":                    "/metrics",
+					"prometheus.io/port":                    "8000",
+					"serving.knative.dev/progress-deadline": "30m",
+				},
 				Containers: []corev1.Container{
 					{Env: []corev1.EnvVar{
 						{

--- a/controllers/utils/nim.go
+++ b/controllers/utils/nim.go
@@ -19,6 +19,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"github.com/go-logr/logr"
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 	kserveconstants "github.com/kserve/kserve/pkg/constants"
 	"io"
@@ -104,18 +105,18 @@ func init() {
 }
 
 // GetAvailableNimRuntimes is used for fetching a list of available NIM custom runtimes
-func GetAvailableNimRuntimes() ([]NimRuntime, error) {
-	return getNimRuntimes([]NimRuntime{}, 0, 1000)
+func GetAvailableNimRuntimes(logger logr.Logger) ([]NimRuntime, error) {
+	return getNimRuntimes(logger, []NimRuntime{}, 0, 1000)
 }
 
 // ValidateApiKey is used for validating the given API key by retrieving the token and pulling the given custom runtime
-func ValidateApiKey(apiKey string, runtime NimRuntime) error {
-	tokenResp, tokenErr := getRuntimeRegistryToken(apiKey, runtime.Resource)
+func ValidateApiKey(logger logr.Logger, apiKey string, runtime NimRuntime) error {
+	tokenResp, tokenErr := getRuntimeRegistryToken(logger, apiKey, runtime.Resource)
 	if tokenErr != nil {
 		return tokenErr
 	}
 
-	manifestErr := attemptToPullManifest(runtime, tokenResp)
+	manifestErr := attemptToPullManifest(logger, runtime, tokenResp)
 	if manifestErr != nil {
 		return manifestErr
 	}
@@ -124,16 +125,16 @@ func ValidateApiKey(apiKey string, runtime NimRuntime) error {
 }
 
 // GetNimModelData is used for fetching the model info for the given runtimes, returns configmap data
-func GetNimModelData(apiKey string, runtimes []NimRuntime) (map[string]string, error) {
+func GetNimModelData(logger logr.Logger, apiKey string, runtimes []NimRuntime) (map[string]string, error) {
 	data := map[string]string{}
-	tokenResp, tokenErr := getNgcToken(apiKey)
+	tokenResp, tokenErr := getNgcToken(logger, apiKey)
 	if tokenErr != nil {
 		return data, tokenErr
 	}
 
 	var modelErr error
 	for _, runtime := range runtimes {
-		model, unmarshaled, err := getModelData(runtime, tokenResp)
+		model, unmarshaled, err := getModelData(logger, runtime, tokenResp)
 		if err != nil {
 			modelErr = err
 			break
@@ -150,7 +151,7 @@ func GetNimModelData(apiKey string, runtimes []NimRuntime) (map[string]string, e
 
 // getNimRuntimes is used to send multiple requests to NVIDIA NIM runtimes endpoint, response pagination-based.
 // it parses the runtimes from every response and returns a list of all runtimes
-func getNimRuntimes(runtimes []NimRuntime, page, pageSize int) ([]NimRuntime, error) {
+func getNimRuntimes(logger logr.Logger, runtimes []NimRuntime, page, pageSize int) ([]NimRuntime, error) {
 	req, reqErr := http.NewRequest("GET", nimGetNgcCatalog, nil)
 	if reqErr != nil {
 		return runtimes, reqErr
@@ -166,6 +167,7 @@ func getNimRuntimes(runtimes []NimRuntime, page, pageSize int) ([]NimRuntime, er
 	if respErr != nil {
 		return runtimes, respErr
 	}
+	logApiResponse(logger, req, resp)
 
 	body, bodyErr := io.ReadAll(resp.Body)
 	if bodyErr != nil {
@@ -179,10 +181,26 @@ func getNimRuntimes(runtimes []NimRuntime, page, pageSize int) ([]NimRuntime, er
 
 	runtimes = append(runtimes, mapNimCatalogResponseToRuntimeList(catRes)...)
 	if catRes.Params.Page < catRes.ResultPageTotal-1 {
-		return getNimRuntimes(runtimes, page+1, pageSize)
+		return getNimRuntimes(logger, runtimes, page+1, pageSize)
 	}
 
 	return runtimes, nil
+}
+
+func logApiResponse(logger logr.Logger, req *http.Request, resp *http.Response) {
+	logger.V(1).Info(fmt.Sprintf("sending api request %s", req.URL))
+
+	logger.V(1).Info(fmt.Sprintf("got api response %s", resp.Status))
+	if resp.StatusCode != http.StatusOK {
+		if resp.ContentLength > 0 {
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				logger.V(1).Error(err, "failed to parse body")
+			} else {
+				logger.V(1).Info(fmt.Sprintf("got body %s", string(body)))
+			}
+		}
+	}
 }
 
 // mapNimCatalogResponseToRuntimeList is used for parsing the ngc catalog response to a list of available runtimes
@@ -212,7 +230,7 @@ func mapNimCatalogResponseToRuntimeList(resp *NimCatalogResponse) []NimRuntime {
 }
 
 // getRuntimeRegistryToken is used for fetching the token required for accessing NIM's runtimes
-func getRuntimeRegistryToken(apiKey, repo string) (*NimTokenResponse, error) {
+func getRuntimeRegistryToken(logger logr.Logger, apiKey, repo string) (*NimTokenResponse, error) {
 	req, reqErr := http.NewRequest("GET", fmt.Sprintf(nimGetRuntimeTokenFmt, repo), nil)
 	if reqErr != nil {
 		return nil, reqErr
@@ -221,11 +239,11 @@ func getRuntimeRegistryToken(apiKey, repo string) (*NimTokenResponse, error) {
 	encoded := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("$oauthtoken:%s", apiKey)))
 	req.Header.Add("Authorization", fmt.Sprintf("Basic %s", encoded))
 
-	return requestToken(req)
+	return requestToken(logger, req)
 }
 
 // getNgcToken is used for fetching the token required for accessing NIM's models
-func getNgcToken(apiKey string) (*NimTokenResponse, error) {
+func getNgcToken(logger logr.Logger, apiKey string) (*NimTokenResponse, error) {
 	req, reqErr := http.NewRequest("GET", nimGetNgcToken, nil)
 	if reqErr != nil {
 		return nil, reqErr
@@ -233,15 +251,16 @@ func getNgcToken(apiKey string) (*NimTokenResponse, error) {
 
 	req.Header.Add("Authorization", fmt.Sprintf("ApiKey %s", apiKey))
 
-	return requestToken(req)
+	return requestToken(logger, req)
 }
 
 // requestToken is used for sending a token requests and parse the response
-func requestToken(req *http.Request) (*NimTokenResponse, error) {
+func requestToken(logger logr.Logger, req *http.Request) (*NimTokenResponse, error) {
 	resp, respErr := NimHttpClient.Do(req)
 	if respErr != nil {
 		return nil, respErr
 	}
+	logApiResponse(logger, req, resp)
 
 	body, bodyErr := io.ReadAll(resp.Body)
 	if bodyErr != nil {
@@ -257,7 +276,7 @@ func requestToken(req *http.Request) (*NimTokenResponse, error) {
 }
 
 // attemptToPullManifest is used for pulling a runtime for verifying access
-func attemptToPullManifest(runtime NimRuntime, tokenResp *NimTokenResponse) error {
+func attemptToPullManifest(logger logr.Logger, runtime NimRuntime, tokenResp *NimTokenResponse) error {
 	req, reqErr := http.NewRequest("GET", fmt.Sprintf(nimGetRuntimeManifestFmt, runtime.Resource, runtime.Version), nil)
 	if reqErr != nil {
 		return reqErr
@@ -270,6 +289,7 @@ func attemptToPullManifest(runtime NimRuntime, tokenResp *NimTokenResponse) erro
 	if respErr != nil {
 		return respErr
 	}
+	logApiResponse(logger, req, resp)
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("failed to pull manifest")
@@ -279,7 +299,7 @@ func attemptToPullManifest(runtime NimRuntime, tokenResp *NimTokenResponse) erro
 }
 
 // getModelData is used for fetching NIM model data for the given runtime
-func getModelData(runtime NimRuntime, tokenResp *NimTokenResponse) (*NimModel, string, error) {
+func getModelData(logger logr.Logger, runtime NimRuntime, tokenResp *NimTokenResponse) (*NimModel, string, error) {
 	req, reqErr := http.NewRequest("GET", fmt.Sprintf(nimGetNgcModelDataFmt, runtime.Org, runtime.Team, runtime.Image), nil)
 	if reqErr != nil {
 		return nil, "", reqErr
@@ -291,6 +311,7 @@ func getModelData(runtime NimRuntime, tokenResp *NimTokenResponse) (*NimModel, s
 	if respErr != nil {
 		return nil, "", respErr
 	}
+	logApiResponse(logger, req, resp)
 
 	body, bodyErr := io.ReadAll(resp.Body)
 	if bodyErr != nil {

--- a/controllers/utils/nim.go
+++ b/controllers/utils/nim.go
@@ -105,7 +105,7 @@ func init() {
 
 // GetAvailableNimRuntimes is used for fetching a list of available NIM custom runtimes
 func GetAvailableNimRuntimes() ([]NimRuntime, error) {
-	return getNimRuntimes([]NimRuntime{}, 0, 100)
+	return getNimRuntimes([]NimRuntime{}, 0, 1000)
 }
 
 // ValidateApiKey is used for validating the given API key by retrieving the token and pulling the given custom runtime

--- a/controllers/utils/nim.go
+++ b/controllers/utils/nim.go
@@ -248,6 +248,7 @@ func attemptToPullManifest(runtime NimRuntime, tokenResp *NimTokenResponse) erro
 	}
 
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", tokenResp.Token))
+	req.Header.Add("Accept", "application/vnd.oci.image.index.v1+json")
 
 	resp, respErr := NimHttpClient.Do(req)
 	if respErr != nil {

--- a/controllers/utils/nim.go
+++ b/controllers/utils/nim.go
@@ -110,18 +110,27 @@ func GetAvailableNimRuntimes(logger logr.Logger) ([]NimRuntime, error) {
 }
 
 // ValidateApiKey is used for validating the given API key by retrieving the token and pulling the given custom runtime
-func ValidateApiKey(logger logr.Logger, apiKey string, runtime NimRuntime) error {
-	tokenResp, tokenErr := getRuntimeRegistryToken(logger, apiKey, runtime.Resource)
-	if tokenErr != nil {
-		return tokenErr
-	}
+func ValidateApiKey(logger logr.Logger, apiKey string, runtimes []NimRuntime) error {
+	for _, runtime := range runtimes {
+		tokenResp, tokenErr := getRuntimeRegistryToken(logger, apiKey, runtime.Resource)
+		if tokenErr != nil {
+			return tokenErr
+		}
 
-	manifestErr := attemptToPullManifest(logger, runtime, tokenResp)
-	if manifestErr != nil {
-		return manifestErr
-	}
+		manifestResp, manifestErr := attemptToPullManifest(logger, runtime, tokenResp)
+		if manifestErr != nil {
+			return manifestErr
+		}
 
-	return nil
+		switch manifestResp.StatusCode {
+		case http.StatusUnavailableForLegalReasons:
+			continue
+		case http.StatusOK:
+			return nil
+		}
+		break
+	}
+	return fmt.Errorf("failed to validate api key")
 }
 
 // GetNimModelData is used for fetching the model info for the given runtimes, returns configmap data
@@ -132,20 +141,15 @@ func GetNimModelData(logger logr.Logger, apiKey string, runtimes []NimRuntime) (
 		return data, tokenErr
 	}
 
-	var modelErr error
 	for _, runtime := range runtimes {
-		model, unmarshaled, err := getModelData(logger, runtime, tokenResp)
-		if err != nil {
-			modelErr = err
-			break
+		if model, unmarshaled := getModelData(logger, runtime, tokenResp); model != nil {
+			data[model.Name] = unmarshaled
 		}
-		data[model.Name] = unmarshaled
 	}
 
-	if modelErr != nil {
-		return nil, modelErr
+	if len(data) < 1 {
+		return nil, fmt.Errorf("no models found")
 	}
-
 	return data, nil
 }
 
@@ -163,11 +167,10 @@ func getNimRuntimes(logger logr.Logger, runtimes []NimRuntime, page, pageSize in
 
 	req.URL.RawQuery = query.Encode()
 
-	resp, respErr := NimHttpClient.Do(req)
+	resp, respErr := handleRequest(logger, req)
 	if respErr != nil {
 		return runtimes, respErr
 	}
-	logApiResponse(logger, req, resp)
 
 	body, bodyErr := io.ReadAll(resp.Body)
 	if bodyErr != nil {
@@ -185,22 +188,6 @@ func getNimRuntimes(logger logr.Logger, runtimes []NimRuntime, page, pageSize in
 	}
 
 	return runtimes, nil
-}
-
-func logApiResponse(logger logr.Logger, req *http.Request, resp *http.Response) {
-	logger.V(1).Info(fmt.Sprintf("sending api request %s", req.URL))
-
-	logger.V(1).Info(fmt.Sprintf("got api response %s", resp.Status))
-	if resp.StatusCode != http.StatusOK {
-		if resp.ContentLength > 0 {
-			body, err := io.ReadAll(resp.Body)
-			if err != nil {
-				logger.V(1).Error(err, "failed to parse body")
-			} else {
-				logger.V(1).Info(fmt.Sprintf("got body %s", string(body)))
-			}
-		}
-	}
 }
 
 // mapNimCatalogResponseToRuntimeList is used for parsing the ngc catalog response to a list of available runtimes
@@ -256,11 +243,10 @@ func getNgcToken(logger logr.Logger, apiKey string) (*NimTokenResponse, error) {
 
 // requestToken is used for sending a token requests and parse the response
 func requestToken(logger logr.Logger, req *http.Request) (*NimTokenResponse, error) {
-	resp, respErr := NimHttpClient.Do(req)
+	resp, respErr := handleRequest(logger, req)
 	if respErr != nil {
 		return nil, respErr
 	}
-	logApiResponse(logger, req, resp)
 
 	body, bodyErr := io.ReadAll(resp.Body)
 	if bodyErr != nil {
@@ -276,54 +262,78 @@ func requestToken(logger logr.Logger, req *http.Request) (*NimTokenResponse, err
 }
 
 // attemptToPullManifest is used for pulling a runtime for verifying access
-func attemptToPullManifest(logger logr.Logger, runtime NimRuntime, tokenResp *NimTokenResponse) error {
+func attemptToPullManifest(logger logr.Logger, runtime NimRuntime, tokenResp *NimTokenResponse) (*http.Response, error) {
 	req, reqErr := http.NewRequest("GET", fmt.Sprintf(nimGetRuntimeManifestFmt, runtime.Resource, runtime.Version), nil)
 	if reqErr != nil {
-		return reqErr
+		return nil, reqErr
 	}
 
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", tokenResp.Token))
 	req.Header.Add("Accept", "application/vnd.oci.image.index.v1+json")
 
-	resp, respErr := NimHttpClient.Do(req)
-	if respErr != nil {
-		return respErr
-	}
-	logApiResponse(logger, req, resp)
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed to pull manifest")
-	}
-
-	return nil
+	return handleRequest(logger, req)
 }
 
 // getModelData is used for fetching NIM model data for the given runtime
-func getModelData(logger logr.Logger, runtime NimRuntime, tokenResp *NimTokenResponse) (*NimModel, string, error) {
+func getModelData(logger logr.Logger, runtime NimRuntime, tokenResp *NimTokenResponse) (*NimModel, string) {
 	req, reqErr := http.NewRequest("GET", fmt.Sprintf(nimGetNgcModelDataFmt, runtime.Org, runtime.Team, runtime.Image), nil)
 	if reqErr != nil {
-		return nil, "", reqErr
+		logger.Error(reqErr, "failed to construct request")
+		return nil, ""
 	}
 
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", tokenResp.Token))
 
-	resp, respErr := NimHttpClient.Do(req)
+	resp, respErr := handleRequest(logger, req)
 	if respErr != nil {
-		return nil, "", respErr
+		return nil, ""
 	}
-	logApiResponse(logger, req, resp)
+
+	if resp.StatusCode != http.StatusOK {
+		sErr := fmt.Errorf("got response %s", resp.Status)
+		if resp.StatusCode == http.StatusUnavailableForLegalReasons {
+			logger.Info("content not available for legal reasons")
+		} else {
+			logger.Error(sErr, "unexpected response status code")
+		}
+		return nil, ""
+	}
 
 	body, bodyErr := io.ReadAll(resp.Body)
 	if bodyErr != nil {
-		return nil, "", bodyErr
+		logger.Error(bodyErr, "failed to read response body")
+		return nil, ""
 	}
 
 	model := &NimModel{}
 	if err := json.Unmarshal(body, model); err != nil {
-		return nil, "", err
+		logger.Error(err, "failed to deserialize body")
+		return nil, ""
+	}
+	return model, string(body)
+}
+
+func handleRequest(logger logr.Logger, req *http.Request) (*http.Response, error) {
+	logger.V(1).Info(fmt.Sprintf("sending api request %s", req.URL))
+
+	resp, doErr := NimHttpClient.Do(req)
+	if doErr != nil {
+		logger.Error(doErr, "failed to send request")
+		return nil, doErr
 	}
 
-	return model, string(body), nil
+	logger.V(1).Info(fmt.Sprintf("got api response %s", resp.Status))
+	if resp.StatusCode != http.StatusOK {
+		if resp.ContentLength > 0 {
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				logger.V(1).Error(err, "failed to parse body")
+			} else {
+				logger.V(1).Info(fmt.Sprintf("got body %s", string(body)))
+			}
+		}
+	}
+	return resp, nil
 }
 
 // GetNimServingRuntimeTemplate returns the Template used by ODH for creating serving runtimes

--- a/controllers/utils/nim.go
+++ b/controllers/utils/nim.go
@@ -42,6 +42,10 @@ type (
 
 	// NimCatalogResponse represents the NIM catalog fetch response
 	NimCatalogResponse struct {
+		ResultPageTotal int `json:"resultPageTotal"`
+		Params          struct {
+			Page int `json:"page"`
+		} `json:"params"`
 		Results []struct {
 			GroupValue string `json:"groupValue"`
 			Resources  []struct {
@@ -101,33 +105,7 @@ func init() {
 
 // GetAvailableNimRuntimes is used for fetching a list of available NIM custom runtimes
 func GetAvailableNimRuntimes() ([]NimRuntime, error) {
-	req, reqErr := http.NewRequest("GET", nimGetNgcCatalog, nil)
-	if reqErr != nil {
-		return nil, reqErr
-	}
-
-	params, _ := json.Marshal(NimCatalogQuery{Query: "orgName:nim", Page: 0, PageSize: 100})
-	query := req.URL.Query()
-	query.Add("q", string(params))
-
-	req.URL.RawQuery = query.Encode()
-
-	resp, respErr := NimHttpClient.Do(req)
-	if respErr != nil {
-		return nil, respErr
-	}
-
-	body, bodyErr := io.ReadAll(resp.Body)
-	if bodyErr != nil {
-		return nil, bodyErr
-	}
-
-	catRes := &NimCatalogResponse{}
-	if err := json.Unmarshal(body, catRes); err != nil {
-		return nil, err
-	}
-
-	return mapNimCatalogResponseToRuntimeList(catRes), nil
+	return getNimRuntimes([]NimRuntime{}, 0, 100)
 }
 
 // ValidateApiKey is used for validating the given API key by retrieving the token and pulling the given custom runtime
@@ -170,6 +148,43 @@ func GetNimModelData(apiKey string, runtimes []NimRuntime) (map[string]string, e
 	return data, nil
 }
 
+// getNimRuntimes is used to send multiple requests to NVIDIA NIM runtimes endpoint, response pagination-based.
+// it parses the runtimes from every response and returns a list of all runtimes
+func getNimRuntimes(runtimes []NimRuntime, page, pageSize int) ([]NimRuntime, error) {
+	req, reqErr := http.NewRequest("GET", nimGetNgcCatalog, nil)
+	if reqErr != nil {
+		return runtimes, reqErr
+	}
+
+	params, _ := json.Marshal(NimCatalogQuery{Query: "orgName:nim", Page: page, PageSize: pageSize})
+	query := req.URL.Query()
+	query.Add("q", string(params))
+
+	req.URL.RawQuery = query.Encode()
+
+	resp, respErr := NimHttpClient.Do(req)
+	if respErr != nil {
+		return runtimes, respErr
+	}
+
+	body, bodyErr := io.ReadAll(resp.Body)
+	if bodyErr != nil {
+		return runtimes, bodyErr
+	}
+
+	catRes := &NimCatalogResponse{}
+	if err := json.Unmarshal(body, catRes); err != nil {
+		return runtimes, err
+	}
+
+	runtimes = append(runtimes, mapNimCatalogResponseToRuntimeList(catRes)...)
+	if catRes.Params.Page < catRes.ResultPageTotal-1 {
+		return getNimRuntimes(runtimes, page+1, pageSize)
+	}
+
+	return runtimes, nil
+}
+
 // mapNimCatalogResponseToRuntimeList is used for parsing the ngc catalog response to a list of available runtimes
 func mapNimCatalogResponseToRuntimeList(resp *NimCatalogResponse) []NimRuntime {
 	var runtimes []NimRuntime
@@ -192,6 +207,7 @@ func mapNimCatalogResponseToRuntimeList(resp *NimCatalogResponse) []NimRuntime {
 			}
 		}
 	}
+
 	return runtimes
 }
 

--- a/hack/verify_nvidia_nim_api.go
+++ b/hack/verify_nvidia_nim_api.go
@@ -67,7 +67,7 @@ func main() {
 		}
 	}
 
-	if vErr := utils.ValidateApiKey(logger, apiKey, runtimes[0]); vErr != nil {
+	if vErr := utils.ValidateApiKey(logger, apiKey, runtimes); vErr != nil {
 		panic(vErr)
 	}
 	fmt.Println("API Key validated successfully")

--- a/hack/verify_nvidia_nim_api.go
+++ b/hack/verify_nvidia_nim_api.go
@@ -20,9 +20,11 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/opendatahub-io/odh-model-controller/controllers/utils"
 	"os"
 	"strings"
+
+	"github.com/opendatahub-io/odh-model-controller/controllers/utils"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 // Use this script for validating NVIDIA API access used by the NIM Account Controller.
@@ -41,6 +43,7 @@ import (
 // ** add -verbose to the script name to print the runtime images and models (it's a lot of data).
 func main() {
 	verbose := flag.Bool("verbose", false, "verbose")
+	logger := zap.New()
 
 	flag.Parse()
 	if len(flag.Args()) < 1 {
@@ -48,7 +51,7 @@ func main() {
 	}
 	apiKey := flag.Arg(0)
 
-	runtimes, rErr := utils.GetAvailableNimRuntimes()
+	runtimes, rErr := utils.GetAvailableNimRuntimes(logger)
 	if rErr != nil {
 		panic(rErr)
 	}
@@ -64,12 +67,12 @@ func main() {
 		}
 	}
 
-	if vErr := utils.ValidateApiKey(apiKey, runtimes[0]); vErr != nil {
+	if vErr := utils.ValidateApiKey(logger, apiKey, runtimes[0]); vErr != nil {
 		panic(vErr)
 	}
 	fmt.Println("API Key validated successfully")
 
-	models, dErr := utils.GetNimModelData(apiKey, runtimes)
+	models, dErr := utils.GetNimModelData(logger, apiKey, runtimes)
 	if dErr != nil {
 		panic(dErr)
 	}
@@ -89,5 +92,4 @@ func main() {
 			fmt.Println()
 		}
 	}
-
 }


### PR DESCRIPTION
# Description

Backporting various fixes done for the NIM Integration in version 2.17-2.19. Only backend-related fixes were selected, with no ramifications for the frontend.

This PR was tested by deploying it into clusters located in and out of the EU:
- Enabled the app tile.
- Verfied the Account's status.
- Deployed a NIM model.
- Examined the logs.

## Backport version 2.19

### Blocked content fails metadata scraping

Jira: [NVPE-194](https://issues.redhat.com/browse/NVPE-194)
Backported from version 2.19: [NVPE-193](https://issues.redhat.com/browse/NVPE-193), https://github.com/opendatahub-io/odh-model-controller/pull/390.

### Log NVIDIA's API response info

Jira: [NVPE-195](https://issues.redhat.com/browse/NVPE-195)
Backported from version 2.19: [NVPE-143](https://issues.redhat.com/browse/NVPE-143), https://github.com/opendatahub-io/odh-model-controller/pull/383.

### Filter triggering events

Jira: [NVPE-199](https://issues.redhat.com/browse/NVPE-199)
Backported from version 2.19: [NVPE-91](https://issues.redhat.com/browse/NVPE-91), https://github.com/opendatahub-io/odh-model-controller/pull/384.

## Backport version 2.18

### The API key is invalidated randomly

Jira: [NVPE-191](https://issues.redhat.com/browse/NVPE-191).
Backported from version 2.18: [NVPE-137](https://issues.redhat.com/browse/NVPE-137), https://github.com/opendatahub-io/odh-model-controller/pull/362.

### Deployment terminated prematurely

Jira: [NVPE-192](https://issues.redhat.com/browse/NVPE-192).
Backported from version 2.18: [NVPE-138](https://issues.redhat.com/browse/NVPE-138), https://github.com/opendatahub-io/odh-model-controller/pull/363.

## Backport version 2.17

### Set NVIDIA API response page size to 1000

Jira: [NVPE-198]
Backported from version 2.17: [NVPE-100](https://issues.redhat.com/browse/NVPE-100), https://github.com/opendatahub-io/odh-model-controller/pull/344.

### Handle NVIDIA API response pagination

Jira: [NVPE-197](https://issues.redhat.com/browse/NVPE-197)
Backported from version 2.17: [NVPE-79](https://issues.redhat.com/browse/NVPE-79), https://github.com/opendatahub-io/odh-model-controller/pull/332.

