### PR TITLE
Use annotation instead of label to enable auth for RawDeployment (#382)

### DIFF
--- a/internal/controller/constants/constants.go
+++ b/internal/controller/constants/constants.go
@@ -30,8 +30,8 @@ const (
 	KserveNetworkVisibility          = "networking.kserve.io/visibility"
 	KserveGroupAnnotation            = "serving.kserve.io/inferenceservice"
 
+	EnableAuthODHAnnotation   = "security.opendatahub.io/enable-auth"
 	LabelAuthGroup            = "security.opendatahub.io/authorization-group"
-	LabelEnableAuthODH        = "security.opendatahub.io/enable-auth"
 	LabelEnableAuth           = "enable-auth"
 	LabelEnableRoute          = "enable-route"
 	LabelEnableKserveRawRoute = "exposed"

--- a/internal/controller/resources/authconfig.go
+++ b/internal/controller/resources/authconfig.go
@@ -208,7 +208,7 @@ func NewKServeAuthTypeDetector(client client.Client) AuthTypeDetector {
 }
 
 func (k *kserveAuthTypeDetector) Detect(_ context.Context, annotations map[string]string) AuthType {
-	if value, exist := annotations[constants.LabelEnableAuthODH]; exist {
+	if value, exist := annotations[constants.EnableAuthODHAnnotation]; exist {
 		if strings.ToLower(value) == "true" {
 			return UserDefined
 		}

--- a/internal/controller/serving/inferencegraph_controller_test.go
+++ b/internal/controller/serving/inferencegraph_controller_test.go
@@ -125,7 +125,7 @@ var _ = Describe("InferenceGraph Controller", func() {
 
 		It("if auth is explicitly disabled, an anonymous AuthConfig should be created", func() {
 			inferenceGraph := buildInferenceGraph("auth-annotation-disabled")
-			inferenceGraph.Annotations[constants.LabelEnableAuthODH] = "false"
+			inferenceGraph.Annotations[constants.EnableAuthODHAnnotation] = "false"
 			createInferenceGraph(&inferenceGraph, buildInferenceGraphStatus(exampleComUrl))
 			defer func() { _ = k8sClient.Delete(ctx, &inferenceGraph) }()
 
@@ -143,7 +143,7 @@ var _ = Describe("InferenceGraph Controller", func() {
 
 		It("if auth is explicitly enabled, a user-defined AuthConfig should be created", func() {
 			inferenceGraph := buildInferenceGraph("auth-annotation-enabled")
-			inferenceGraph.Annotations[constants.LabelEnableAuthODH] = "true"
+			inferenceGraph.Annotations[constants.EnableAuthODHAnnotation] = "true"
 			createInferenceGraph(&inferenceGraph, buildInferenceGraphStatus(exampleComUrl))
 			defer func() { _ = k8sClient.Delete(ctx, &inferenceGraph) }()
 
@@ -161,7 +161,7 @@ var _ = Describe("InferenceGraph Controller", func() {
 
 		It("if auth is explicitly enabled but InferenceGraph is not ready, no AuthConfig should be created", func() {
 			inferenceGraph := buildInferenceGraph("auth-annotation-enabled-ig-not-ready")
-			inferenceGraph.Annotations[constants.LabelEnableAuthODH] = "true"
+			inferenceGraph.Annotations[constants.EnableAuthODHAnnotation] = "true"
 			createInferenceGraph(&inferenceGraph, buildInferenceGraphStatus(emptyUrl))
 			defer func() { _ = k8sClient.Delete(ctx, &inferenceGraph) }()
 
@@ -174,7 +174,7 @@ var _ = Describe("InferenceGraph Controller", func() {
 
 		It("if auth is explicitly enabled but Authorino is not configured, no AuthConfig should be created", func() {
 			inferenceGraph := buildInferenceGraph("auth-annotation-enabled-authorino-missing")
-			inferenceGraph.Annotations[constants.LabelEnableAuthODH] = "true"
+			inferenceGraph.Annotations[constants.EnableAuthODHAnnotation] = "true"
 			createInferenceGraph(&inferenceGraph, buildInferenceGraphStatus(exampleComUrl))
 			defer func() { _ = k8sClient.Delete(ctx, &inferenceGraph) }()
 

--- a/internal/controller/serving/inferenceservice_controller_test.go
+++ b/internal/controller/serving/inferenceservice_controller_test.go
@@ -1039,8 +1039,7 @@ var _ = Describe("InferenceService Controller", func() {
 			It("it should create a default clusterrolebinding for auth", func() {
 				_ = createServingRuntime(testNs, KserveServingRuntimePath1)
 				inferenceService := createInferenceService(testNs, KserveOvmsInferenceServiceName, KserveInferenceServicePath1)
-				inferenceService.Labels = map[string]string{}
-				inferenceService.Labels[constants.LabelEnableAuthODH] = "true"
+				inferenceService.Annotations[constants.EnableAuthODHAnnotation] = "true"
 				if err := k8sClient.Create(ctx, inferenceService); err != nil && !k8sErrors.IsAlreadyExists(err) {
 					Expect(err).NotTo(HaveOccurred())
 				}
@@ -1062,8 +1061,7 @@ var _ = Describe("InferenceService Controller", func() {
 				serviceAccountName := "custom-sa"
 				_ = createServingRuntime(testNs, KserveServingRuntimePath1)
 				inferenceService := createInferenceService(testNs, KserveOvmsInferenceServiceName, KserveInferenceServicePath1)
-				inferenceService.Labels = map[string]string{}
-				inferenceService.Labels[constants.LabelEnableAuthODH] = "true"
+				inferenceService.Annotations[constants.EnableAuthODHAnnotation] = "true"
 				inferenceService.Spec.Predictor.ServiceAccountName = serviceAccountName
 				if err := k8sClient.Create(ctx, inferenceService); err != nil && !k8sErrors.IsAlreadyExists(err) {
 					Expect(err).NotTo(HaveOccurred())
@@ -1196,27 +1194,23 @@ var _ = Describe("InferenceService Controller", func() {
 				_ = createServingRuntime(testNs, KserveServingRuntimePath1)
 				// create 2 isvcs with no SA (i.e default) and 2 with a custom SA
 				defaultIsvc1 := createInferenceService(testNs, "default-1", KserveInferenceServicePath1)
-				defaultIsvc1.Labels = map[string]string{}
-				defaultIsvc1.Labels[constants.LabelEnableAuthODH] = "true"
+				defaultIsvc1.Annotations[constants.EnableAuthODHAnnotation] = "true"
 				if err := k8sClient.Create(ctx, defaultIsvc1); err != nil {
 					Expect(err).NotTo(HaveOccurred())
 				}
 				defaultIsvc2 := createInferenceService(testNs, "default-2", KserveInferenceServicePath1)
-				defaultIsvc2.Labels = map[string]string{}
-				defaultIsvc2.Labels[constants.LabelEnableAuthODH] = "true"
+				defaultIsvc2.Annotations[constants.EnableAuthODHAnnotation] = "true"
 				if err := k8sClient.Create(ctx, defaultIsvc2); err != nil {
 					Expect(err).NotTo(HaveOccurred())
 				}
 				customIsvc1 := createInferenceService(testNs, "custom-1", KserveInferenceServicePath1)
-				customIsvc1.Labels = map[string]string{}
-				customIsvc1.Labels[constants.LabelEnableAuthODH] = "true"
+				customIsvc1.Annotations[constants.EnableAuthODHAnnotation] = "true"
 				customIsvc1.Spec.Predictor.ServiceAccountName = customServiceAccountName
 				if err := k8sClient.Create(ctx, customIsvc1); err != nil {
 					Expect(err).NotTo(HaveOccurred())
 				}
 				customIsvc2 := createInferenceService(testNs, "custom-2", KserveInferenceServicePath1)
-				customIsvc2.Labels = map[string]string{}
-				customIsvc2.Labels[constants.LabelEnableAuthODH] = "true"
+				customIsvc2.Annotations[constants.EnableAuthODHAnnotation] = "true"
 				customIsvc2.Spec.Predictor.ServiceAccountName = customServiceAccountName
 				if err := k8sClient.Create(ctx, customIsvc2); err != nil {
 					Expect(err).NotTo(HaveOccurred())
@@ -1431,7 +1425,7 @@ func disableAuth(isvc *kservev1beta1.InferenceService) error {
 		return err
 	}
 	delete(latestISVC.Annotations, constants.LabelEnableAuth)
-	delete(latestISVC.Annotations, constants.LabelEnableAuthODH)
+	delete(latestISVC.Annotations, constants.EnableAuthODHAnnotation)
 	return k8sClient.Update(context.Background(), latestISVC)
 }
 
@@ -1448,7 +1442,7 @@ func enableAuth(isvc *kservev1beta1.InferenceService) error {
 	if latestISVC.Annotations == nil {
 		latestISVC.Annotations = map[string]string{}
 	}
-	latestISVC.Annotations[constants.LabelEnableAuthODH] = "true"
+	latestISVC.Annotations[constants.EnableAuthODHAnnotation] = "true"
 	return k8sClient.Update(context.Background(), latestISVC)
 }
 

--- a/internal/controller/serving/reconcilers/kserve_raw_clusterrolebinding_reconciler.go
+++ b/internal/controller/serving/reconcilers/kserve_raw_clusterrolebinding_reconciler.go
@@ -108,7 +108,7 @@ func (r *KserveRawClusterRoleBindingReconciler) Delete(ctx context.Context, log 
 }
 
 func (r *KserveRawClusterRoleBindingReconciler) createDesiredResource(isvc *kservev1beta1.InferenceService) *v1.ClusterRoleBinding {
-	if val, ok := isvc.Labels[constants.LabelEnableAuthODH]; !ok || val != "true" {
+	if val, ok := isvc.Annotations[constants.EnableAuthODHAnnotation]; !ok || val != "true" {
 		return nil
 	}
 

--- a/internal/controller/serving/reconcilers/kserve_raw_route_reconciler.go
+++ b/internal/controller/serving/reconcilers/kserve_raw_route_reconciler.go
@@ -87,7 +87,7 @@ func (r *KserveRawRouteReconciler) Cleanup(_ context.Context, _ logr.Logger, _ s
 func (r *KserveRawRouteReconciler) createDesiredResource(ctx context.Context, log logr.Logger, isvc *kservev1beta1.InferenceService) (*v1.Route, error) {
 	var err error
 	enableAuth := false
-	if enableAuth, err = strconv.ParseBool(isvc.Labels[constants.LabelEnableAuthODH]); err != nil {
+	if enableAuth, err = strconv.ParseBool(isvc.Annotations[constants.EnableAuthODHAnnotation]); err != nil {
 		enableAuth = false
 	}
 	createRoute := false


### PR DESCRIPTION
* Use annotation instead of label to enable auth for RawDeployment

Signed-off-by: Vedant Mahabaleshwarkar <vmahabal@redhat.com>

* rename variable

Signed-off-by: Vedant Mahabaleshwarkar <vmahabal@redhat.com>

---------

Signed-off-by: Vedant Mahabaleshwarkar <vmahabal@redhat.com>
(cherry picked from commit 9a2ac9a8eec7618c1b68e5125a8d2c55b840255d)