### PR TITLE
[RHOAIENG-20597] vLLM Serving Runtime Template naming changes

### DIFF
--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -78,11 +78,11 @@ replacements:
       kind: ConfigMap
       version: v1
       name: odh-model-controller-parameters
-      fieldPath: data.vllm-image
+      fieldPath: data.vllm-cuda-image
     targets:
       - select:
           kind: Template
-          name: vllm-runtime-template
+          name: vllm-cuda-runtime-template
         fieldPaths:
           - objects.0.spec.containers.0.image
       - select:

--- a/config/base/params.env
+++ b/config/base/params.env
@@ -3,5 +3,5 @@ caikit-tgis-image=quay.io/modh/caikit-tgis-serving@sha256:2fb5c995db56e1a6944a54
 caikit-standalone-image=quay.io/modh/caikit-nlp@sha256:2cbc56363820431a14172cd9a3e185e32540f9304810ccfd2f3e23e18d92bd97
 tgis-image=quay.io/modh/text-generation-inference@sha256:aebf545d8048a59174f70334dc90c6b97ead4602a39cb7598ea68c8d199168a2
 ovms-image=quay.io/modh/openvino_model_server@sha256:428c00232cbf3b38a3929a0d22d0e13c6388ce353e3853cc2956d175eacf6724
-vllm-image=quay.io/modh/vllm@sha256:c7d5b9292d915f556c0c1690e5ca48af06847e14e1fc4666b792052f01d4d0c7
+vllm-cuda-image=quay.io/modh/vllm@sha256:c7d5b9292d915f556c0c1690e5ca48af06847e14e1fc4666b792052f01d4d0c7
 

--- a/config/runtimes/kustomization.yaml
+++ b/config/runtimes/kustomization.yaml
@@ -10,7 +10,7 @@ resources:
   - caikit-tgis-template.yaml
   - tgis-template.yaml
   - ovms-kserve-template.yaml
-  - vllm-template.yaml
+  - vllm-cuda-template.yaml
   - vllm-multinode-template.yaml
   - vllm-rocm-template.yaml
   - vllm-gaudi-template.yaml

--- a/config/runtimes/vllm-cuda-template.yaml
+++ b/config/runtimes/vllm-cuda-template.yaml
@@ -5,22 +5,22 @@ metadata:
     opendatahub.io/dashboard: 'true'
     opendatahub.io/ootb: 'true'
   annotations:
-    description: vLLM is a high-throughput and memory-efficient inference and serving engine for LLMs
-    openshift.io/display-name: vLLM ServingRuntime for KServe
+    description: vLLM ServingRuntime with CUDA support (for NVIDIA GPUs) 
+    openshift.io/display-name: vLLM NVIDIA GPU ServingRuntime for KServe
     openshift.io/provider-display-name: Red Hat, Inc.
     tags: rhods,rhoai,kserve,servingruntime
     template.openshift.io/documentation-url: https://github.com/opendatahub-io/vllm
-    template.openshift.io/long-description: This template defines resources needed to deploy vLLM ServingRuntime with KServe in Red Hat OpenShift AI
+    template.openshift.io/long-description: This template defines resources needed to deploy vLLM NVIDIA GPU ServingRuntime with KServe in Red Hat OpenShift AI
     opendatahub.io/modelServingSupport: '["single"]'
     opendatahub.io/apiProtocol: 'REST'
-  name: vllm-runtime-template
+  name: vllm-cuda-runtime-template
 objects:
   - apiVersion: serving.kserve.io/v1alpha1
     kind: ServingRuntime
     metadata:
-      name: vllm-runtime
+      name: vllm-cuda-runtime
       annotations:
-        openshift.io/display-name: vLLM ServingRuntime for KServe
+        openshift.io/display-name: vLLM NVIDIA GPU ServingRuntime for KServe
         opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
       labels:
         opendatahub.io/dashboard: 'true'
@@ -34,7 +34,7 @@ objects:
           name: vLLM
       containers:
         - name: kserve-container
-          image: $(vllm-image)
+          image: $(vllm-cuda-image)
           command:
             - python
             - -m

--- a/config/runtimes/vllm-gaudi-template.yaml
+++ b/config/runtimes/vllm-gaudi-template.yaml
@@ -6,11 +6,11 @@ metadata:
     opendatahub.io/ootb: 'true'
   annotations:
     description: vLLM ServingRuntime to support Gaudi(for Habana AI processors)
-    openshift.io/display-name: vLLM ServingRuntime with Gaudi accelerators support for KServe
+    openshift.io/display-name: vLLM Intel Gaudi Accelerator ServingRuntime for KServe
     openshift.io/provider-display-name: Red Hat, Inc.
     tags: rhods,rhoai,kserve,servingruntime
     template.openshift.io/documentation-url: https://github.com/opendatahub-io/vllm
-    template.openshift.io/long-description: This template defines resources needed to deploy vLLM ServingRuntime with Gaudi accelerators support for KServe in Red Hat OpenShift AI
+    template.openshift.io/long-description: This template defines resources needed to deploy vLLM Intel Gaudi Accelerator ServingRuntime with KServe in Red Hat OpenShift AI
     opendatahub.io/modelServingSupport: '["single"]'
     opendatahub.io/apiProtocol: 'REST'
   name: vllm-gaudi-runtime-template
@@ -20,7 +20,7 @@ objects:
     metadata:
       name: vllm-gaudi-runtime
       annotations:
-        openshift.io/display-name: vLLM ServingRuntime with Gaudi accelerators support for KServe
+        openshift.io/display-name: vLLM Intel Gaudi Accelerator ServingRuntime for KServe
         opendatahub.io/recommended-accelerators: '["habana.ai/gaudi"]'
       labels:
         opendatahub.io/dashboard: 'true'

--- a/config/runtimes/vllm-multinode-template.yaml
+++ b/config/runtimes/vllm-multinode-template.yaml
@@ -6,11 +6,11 @@ metadata:
     opendatahub.io/ootb: 'true'
   annotations:
     description: vLLM is a high-throughput and memory-efficient inference and serving engine for LLMs
-    openshift.io/display-name: vLLM ServingRuntime Multi-Node for KServe
+    openshift.io/display-name: vLLM Multi-Node ServingRuntime for KServe
     openshift.io/provider-display-name: Red Hat, Inc.
     tags: rhods,rhoai,kserve,servingruntime,multi-node
     template.openshift.io/documentation-url: https://github.com/opendatahub-io/vllm
-    template.openshift.io/long-description: This template defines resources needed to deploy vLLM ServingRuntime Multi-Node with KServe in Red Hat OpenShift AI
+    template.openshift.io/long-description: This template defines resources needed to deploy vLLM Multi-Node ServingRuntime with KServe in Red Hat OpenShift AI
     opendatahub.io/modelServingSupport: '["single"]'
     opendatahub.io/apiProtocol: 'REST'
   name: vllm-multinode-runtime-template
@@ -20,7 +20,7 @@ objects:
     metadata:
       name: vllm-multinode-runtime
       annotations:
-        openshift.io/display-name: vLLM ServingRuntime Multi-Node for KServe
+        openshift.io/display-name: vLLM Multi-Node ServingRuntime for KServe
         opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
       labels:
         opendatahub.io/dashboard: 'false'
@@ -35,7 +35,7 @@ objects:
           priority: 2
       containers:
         - name: kserve-container
-          image: $(vllm-image)
+          image: $(vllm-cuda-image)
           command: ['bash', '-c']
           args:
             - |
@@ -176,7 +176,7 @@ objects:
         tensorParallelSize: 1
         containers:
           - name: worker-container
-            image: $(vllm-image)
+            image: $(vllm-cuda-image)
             command: ['bash', '-c']
             args:
               - |

--- a/config/runtimes/vllm-rocm-template.yaml
+++ b/config/runtimes/vllm-rocm-template.yaml
@@ -6,11 +6,11 @@ metadata:
     opendatahub.io/ootb: 'true'
   annotations:
     description: vLLM ServingRuntime to support ROCm (for AMD GPUs)
-    openshift.io/display-name: vLLM ROCm ServingRuntime for KServe
+    openshift.io/display-name: vLLM AMD GPU ServingRuntime for KServe
     openshift.io/provider-display-name: Red Hat, Inc.
     tags: rhods,rhoai,kserve,servingruntime
     template.openshift.io/documentation-url: https://github.com/opendatahub-io/vllm
-    template.openshift.io/long-description: This template defines resources needed to deploy vLLM ServingRuntime with KServe in Red Hat OpenShift AI
+    template.openshift.io/long-description: This template defines resources needed to deploy vLLM AMD GPU ServingRuntime with KServe in Red Hat OpenShift AI
     opendatahub.io/modelServingSupport: '["single"]'
     opendatahub.io/apiProtocol: 'REST'
   name: vllm-rocm-runtime-template
@@ -20,7 +20,7 @@ objects:
     metadata:
       name: vllm-rocm-runtime
       annotations:
-        openshift.io/display-name: vLLM ROCm ServingRuntime for KServe
+        openshift.io/display-name: vLLM AMD GPU ServingRuntime for KServe
         opendatahub.io/recommended-accelerators: '["amd.com/gpu"]'
       labels:
         opendatahub.io/dashboard: 'true'


### PR DESCRIPTION
Signed-off-by: Snomaan6846 <syedali@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

## Description
Making vLLM Serving Runtime Template naming changes to avoid confusion while selecting the model.
Below are the renamed vLLM serving Runtime Template which will be displayed on dashboard

vLLM ServingRuntime for KServe  ->  vLLM NVIDIA GPU ServingRuntime for KServe
vLLM ServingRuntime with Gaudi accelerators support for KServe   ->  vLLM Intel Gaudi Accelerator ServingRuntime for KServe
vLLM ROCm ServingRuntime for KServe  ->  vLLM AMD GPU ServingRuntime for KServe

vLLM ServingRuntime Multi-Node for KServe  ->  vLLM Multi-Node ServingRuntime for KServe
 
Jira Reference : https://issues.redhat.com/browse/RHOAIENG-20597

## How Has This Been Tested?

1. In a cluster that has RHOAI or ODH deployed, use the following DSC:

```
spec:
  components:
    codeflare:
      managementState: Removed
    kserve:
      devFlags:
        manifests:
          - contextDir: config
            sourcePath: ''
            uri: 'https://github.com/Snomaan6846/odh-model-controller/tarball/syedali-20597'
      managementState: Managed
      serving:
        ingressGateway:
          certificate:
            type: OpenshiftDefaultIngress
        managementState: Managed
        name: knative-serving
    modelregistry:
      managementState: Removed
      registriesNamespace: rhoai-model-registries
    trustyai:
      managementState: Removed
    ray:
      managementState: Removed
    kueue:
      managementState: Removed
    workbenches:
      managementState: Removed
    dashboard:
      managementState: Managed
    modelmeshserving:
      managementState: Removed
    datasciencepipelines:
      managementState: Removed
    trainingoperator:
      managementState: Removed
```

2. Ensure that the pods have all reconciled and are running:
```
oc get pods -n redhat-ods-applications
NAME                                        READY   STATUS    RESTARTS   AGE
kserve-controller-manager-c9749c84f-b9pl5   1/1     Running   0          21m
odh-model-controller-6cc9b45767-8nzt9       1/1     Running   0          21m
rhods-dashboard-864bcf4f79-7nzfw            2/2     Running   0          28m
rhods-dashboard-864bcf4f79-7pvnm            2/2     Running   0          28m
rhods-dashboard-864bcf4f79-dwvsw            2/2     Running   0          28m
rhods-dashboard-864bcf4f79-gw2z9            2/2     Running   0          28m
rhods-dashboard-864bcf4f79-lqlqr            2/2     Running   0          28m
```

3. On top right, select OpenShift AI
![image](https://github.com/user-attachments/assets/66da81da-72fd-4c8a-8860-6a1874385dec)

4. In Dashboard, verify all runtimes show up and vLLM ServingRuntime Template names
![image](https://github.com/user-attachments/assets/a081a355-808b-497e-8efd-4e8d71966359)

5. Click on question mark symbol (?) to verify the template/resource name used
![image](https://github.com/user-attachments/assets/84056f4f-b5ca-47c8-b322-104fc056bd9a)

![image](https://github.com/user-attachments/assets/6d3cf74c-acff-4c0d-8ac3-35e416962850)

![image](https://github.com/user-attachments/assets/b598c9b0-9494-4658-85ce-642e92702355)
