### PR TITLE
Update vLLM CPU template addition

### DIFF
--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -7,6 +7,7 @@ namespace: opendatahub
 configMapGenerator:
   - envs:
       - params.env
+      - params-vllm-cpu.env
       - params-vllm-rocm.env
       - params-vllm-gaudi.env
     name: odh-model-controller-parameters
@@ -100,6 +101,17 @@ replacements:
       - select:
           kind: Template
           name: vllm-rocm-runtime-template
+        fieldPaths:
+          - objects.0.spec.containers.0.image
+  - source:
+      kind: ConfigMap
+      version: v1
+      name: odh-model-controller-parameters
+      fieldPath: data.vllm-cpu-image
+    targets:
+      - select:
+          kind: Template
+          name: vllm-cpu-runtime-template
         fieldPaths:
           - objects.0.spec.containers.0.image
   - source:

--- a/config/base/params-vllm-cpu.env
+++ b/config/base/params-vllm-cpu.env
@@ -1,1 +1,1 @@
-vllm-cpu-image=quay.io/modh/vllm:rhoai-v2-19-cpu
+vllm-cpu-image=quay.io/modh/vllm:rhoai-2.19-cpu

--- a/config/runtimes/kustomization.yaml
+++ b/config/runtimes/kustomization.yaml
@@ -14,4 +14,5 @@ resources:
   - vllm-multinode-template.yaml
   - vllm-rocm-template.yaml
   - vllm-gaudi-template.yaml
+  - vllm-cpu-template.yaml
   - caikit-standalone-template.yaml

--- a/config/runtimes/vllm-cpu-template.yaml
+++ b/config/runtimes/vllm-cpu-template.yaml
@@ -10,7 +10,7 @@ metadata:
     openshift.io/provider-display-name: Red Hat, Inc.
     tags: rhods,rhoai,kserve,servingruntime
     template.openshift.io/documentation-url: https://github.com/opendatahub-io/vllm
-    template.openshift.io/long-description: This template defines resources needed to deploy vLLM ServingRuntime with KServe in Red Hat OpenShift AI (ppc64le/s390x architectures only)
+    template.openshift.io/long-description: This template defines resources needed to deploy vLLM CPU ServingRuntime with KServe in Red Hat OpenShift AI (ppc64le/s390x architectures only)
     opendatahub.io/modelServingSupport: '["single"]'
     opendatahub.io/apiProtocol: 'REST'
   name: vllm-cpu-runtime-template


### PR DESCRIPTION
Follow up to @npanpaliya 's PR: https://github.com/red-hat-data-services/odh-model-controller/pull/574 
Updating and completing the addition of vLLM CPU runtime support in RHOAI 2.19
Addresses: https://issues.redhat.com/browse/RHOAIENG-20214
