### PR TITLE
Update OVMS image for 2.19

### DIFF
--- a/config/base/params.env
+++ b/config/base/params.env
@@ -2,5 +2,5 @@ odh-model-controller=quay.io/opendatahub/odh-model-controller:v0.12.0
 caikit-tgis-image=quay.io/modh/caikit-tgis-serving@sha256:2c7eef73708b5d73de33153459ac7238fdcf517cdc3544c775981f5814b4b6ed
 caikit-standalone-image=quay.io/modh/caikit-nlp@sha256:2cbc56363820431a14172cd9a3e185e32540f9304810ccfd2f3e23e18d92bd97
 tgis-image=quay.io/modh/text-generation-inference@sha256:aebf545d8048a59174f70334dc90c6b97ead4602a39cb7598ea68c8d199168a2
-ovms-image=quay.io/modh/openvino_model_server@sha256:428c00232cbf3b38a3929a0d22d0e13c6388ce353e3853cc2956d175eacf6724
+ovms-image=quay.io/modh/openvino_model_server@sha256:53b7fcf95de9b81e4c8652d0bf4e84e22d5b696827a5d951d863420c68b9cfe8
 vllm-cuda-image=quay.io/modh/vllm@sha256:b98dbeb042401115553f8c86dfcd390176e6ea40532f8d8a5946927e4fb15e1d


### PR DESCRIPTION
Updating image of OVMS. Please note there is an even newer 2.19 image in quay, but we won't be using it for now, since it seems to break the inferencing due to newer version of transformers. The one in this PR has been tested and is successful.