### PR TITLE
update instant merge logic

### DIFF
--- a/.github/workflows/instant-merge.yaml
+++ b/.github/workflows/instant-merge.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: instant-merge
-        if: ${{ github.event.sender.login == 'red-hat-konflux[bot]' && ( startsWith(github.event.pull_request.title, 'Update caikit-nlp-') || startsWith(github.event.pull_request.title, 'Update vllm-cuda-') || startsWith(github.event.pull_request.title, 'Update vllm-rocm-') || startsWith(github.event.pull_request.title, 'Update vllm-gaudi-') ) }}
+        if: ${{ github.event.sender.login == 'red-hat-konflux[bot]' && ( contains(github.event.pull_request.title, 'Update caikit-nlp-') || contains(github.event.pull_request.title, 'Update vllm-cuda-') || contains(github.event.pull_request.title, 'Update vllm-rocm-') || contains(github.event.pull_request.title, 'Update vllm-gaudi-') ) }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |


### PR DESCRIPTION
konflux app PRs now are prefixed with 'chore(deps):', so updating instant merge logic from startsWith() to contains()
