### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for odh-model-controller-v2-22

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -32,7 +32,8 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:0d7cfb0704f6d389942150a0
 ARG USER=2000
 
 LABEL com.redhat.component="odh-model-controller-container" \
-      name="managed-open-data-hub/odh-model-controller-rhel8" \
+      name="rhoai/odh-model-controller-rhel9" \
+      cpe="cpe:/a:redhat:openshift_ai:2.22::el9" \
       description="The controller removes the need for users to perform manual steps when deploying their models" \
       summary="odh-model-controller" \
       maintainer="['managed-open-data-hub@redhat.com']" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
