### PR TITLE
fix(build): bump go-toolset builder image to Go 1.25 in Konflux Dockerfile

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -3,7 +3,7 @@ ARG SOURCE_CODE=.
 
 # Build the manager binary
 
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24@sha256:6234f572204d672a0ee0686d748fbb9b7b05679368bf0d7a4446e13970e58060 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25@sha256:6da1160c0e8da15b585560ac6ef7b0179f17686aeaaa477ead6427daf8948fea as builder
 
 # These built-in args are defined in the global scope, and are not automatically accessible within build stages or RUN commands.
 # To expose these arguments inside the build stage, we need to redefine it without a value.


### PR DESCRIPTION
## Description

Konflux push builds were failing at the `go mod download` step - a Go version mismatch between the builder image and `go.mod`.

The module requires Go 1.25.7 but the Konflux Dockerfile was still pinned to `go-toolset:1.24`. When Go 1.24 encounters a `go 1.25.7` directive, it tries to auto-download the required toolchain from the internet - which fails immediately in Konflux's hermetic, network-isolated build environment.

Aligns the builder image with the `go-toolset:1.25` digest already used by all other Containerfiles in this repository.

## How Has This Been Tested?

Build consistency verified by checking all other Containerfiles in this repo already use the same image digest.

## Merge criteria:

- [ ] JIRA(s) are linked in the PR description
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work