### PR TITLE
fix: add required writable volume mounts for NIM 2.x compatibility

### DIFF
--- a/internal/controller/utils/nim.go
+++ b/internal/controller/utils/nim.go
@@ -488,6 +488,26 @@ func GetNimServingRuntimeTemplate(scheme *runtime.Scheme) (*v1alpha1.ServingRunt
 								MountPath: "/.cache",
 								Name:      "nim-cache",
 							},
+							{
+								MountPath: "/opt/nim/nginx",
+								Name:      "nim-nginx",
+							},
+							{
+								MountPath: "/opt/nim/generated_configs",
+								Name:      "nim-generated-configs",
+							},
+							{
+								MountPath: "/opt/nim/.cache",
+								Name:      "nim-dot-cache",
+							},
+							{
+								MountPath: "/opt/nim/.config",
+								Name:      "nim-dot-config",
+							},
+							{
+								MountPath: "/opt/nim/.triton",
+								Name:      "nim-dot-triton",
+							},
 						},
 					},
 				},
@@ -513,6 +533,36 @@ func GetNimServingRuntimeTemplate(scheme *runtime.Scheme) (*v1alpha1.ServingRunt
 					},
 					{
 						Name: "nim-cache",
+						VolumeSource: corev1.VolumeSource{
+							EmptyDir: &corev1.EmptyDirVolumeSource{},
+						},
+					},
+					{
+						Name: "nim-nginx",
+						VolumeSource: corev1.VolumeSource{
+							EmptyDir: &corev1.EmptyDirVolumeSource{},
+						},
+					},
+					{
+						Name: "nim-generated-configs",
+						VolumeSource: corev1.VolumeSource{
+							EmptyDir: &corev1.EmptyDirVolumeSource{},
+						},
+					},
+					{
+						Name: "nim-dot-cache",
+						VolumeSource: corev1.VolumeSource{
+							EmptyDir: &corev1.EmptyDirVolumeSource{},
+						},
+					},
+					{
+						Name: "nim-dot-config",
+						VolumeSource: corev1.VolumeSource{
+							EmptyDir: &corev1.EmptyDirVolumeSource{},
+						},
+					},
+					{
+						Name: "nim-dot-triton",
 						VolumeSource: corev1.VolumeSource{
 							EmptyDir: &corev1.EmptyDirVolumeSource{},
 						},


### PR DESCRIPTION
## Description

NIM 2.x enforces a read-only filesystem under `/opt/nim` at container startup. Several subdirectories must be writable at runtime but are not covered by the existing emptyDir mounts in the NIM ServingRuntime template, causing NIM 2.x deployments to crash immediately with `Permission denied` errors.

This change adds five emptyDir volume mounts to `GetNimServingRuntimeTemplate` in `internal/controller/utils/nim.go`:

- `/opt/nim/nginx` — nginx configuration written at startup
- `/opt/nim/generated_configs` — runtime-generated config files
- `/opt/nim/.cache` — runtime cache directory
- `/opt/nim/.config` — runtime config directory
- `/opt/nim/.triton` — Triton kernel cache

Note: mounting a single emptyDir at `/opt/nim` is not viable — it shadows `start_server.sh` which NVIDIA bakes into the image, causing an immediate startup failure.

Fixes: [NVPE-424](https://redhat.atlassian.net/browse/NVPE-424)
Target: RHOAI 3.3.3 (code freeze May 13)

Upstream PR targeting RHOAI 3.5: [opendatahub-io/odh-model-controller#802](https://github.com/opendatahub-io/odh-model-controller/pull/802)
Upstream PR targeting RHOAI 2.25.6: [opendatahub-io/odh-model-controller#804](https://github.com/opendatahub-io/odh-model-controller/pull/804)

## How Has This Been Tested?

Pre-implementation cluster validation was performed in [NVPE-423](https://redhat.atlassian.net/browse/NVPE-423). Each mount was added one at a time to a live cluster (RHOAI 2.25, A100 GPUs) and verified before proceeding to the next, until NIM 2.0.2 started successfully and served inference requests.

Backward compatibility was confirmed: NIM 1.15.5 starts and serves inference with all five mounts applied.

Unit tests pass: `go test ./...` (excluding e2e).

## Merge criteria:

- [x] JIRA(s) are linked in the PR description
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work