### PR TITLE
fix: reduce NIM ConfigMap size by storing only required model fields

### DIFF
--- a/internal/controller/utils/nim.go
+++ b/internal/controller/utils/nim.go
@@ -382,7 +382,13 @@ func getModelData(logger logr.Logger, runtime NimRuntime, key string) (*NimModel
 		logger.Error(err, "failed to deserialize body")
 		return nil, ""
 	}
-	return model, string(body)
+	// Re-marshal to include only NimModel fields (excludes bloated fields like 'description')
+	minimalJSON, err := json.Marshal(model)
+	if err != nil {
+		logger.Error(err, "failed to serialize minimal model data")
+		return nil, ""
+	}
+	return model, string(minimalJSON)
 }
 
 func handleRequest(logger logr.Logger, req *http.Request) (*http.Response, error) {


### PR DESCRIPTION
## Description

The `odh-nim-account-cm` ConfigMap fails to create when the NIM catalog exceeds ~180 models, because the controller stores the full NVIDIA API response per model (~6KB each, dominated by a `description` field containing HTML/markdown content). This breaks NIM enablement entirely.

This change fixes the issue by re-marshaling only the `NimModel` struct fields instead of storing the raw API response body, reducing the ConfigMap from ~1.1MB to ~165KB (safe with headroom for catalog growth).

Required fields retained: `name`, `displayName`, `shortDescription`, `namespace`, `tags`, `latestTag`, `updatedDate`.

Fixes: [RHOAIENG-59679](https://redhat.atlassian.net/browse/RHOAIENG-59679)
Backport of: [opendatahub-io/odh-model-controller#692](https://github.com/opendatahub-io/odh-model-controller/pull/692) (upstream incubating, RHOAI 3.4)
Previously backported to: [red-hat-data-services/odh-model-controller#1414](https://github.com/red-hat-data-services/odh-model-controller/pull/1414) (rhoai-2.25, RHOAI 2.25.3)

## How Has This Been Tested?

- Verified with a custom image deployed to a test cluster — ConfigMap created successfully with 184+ models
- Unit tests pass

## Merge criteria:

- [x] JIRA(s) are linked in the PR description
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work