### PR TITLE
fix(metrics): fix vLLM REQUEST_COUNT metric query for dashboard

### DIFF
--- a/internal/controller/constants/runtime-metrics.go
+++ b/internal/controller/constants/runtime-metrics.go
@@ -187,7 +187,11 @@ const (
 				"queries": [
 					{
 						"title": "Number of successful incoming requests",
-						"query": "round(sum(increase(vllm:request_success_total{namespace='${NAMESPACE}',model_name='${model_name}'}[${REQUEST_RATE_INTERVAL}])))"
+						"query": "round(sum(increase(vllm:request_success_total{namespace='${NAMESPACE}',model_name='${MODEL_NAME}',finished_reason!~'error|abort'}[${REQUEST_RATE_INTERVAL}])))"
+					},
+					{
+						"title": "Number of failed incoming requests",
+						"query": "round(sum(increase(vllm:request_success_total{namespace='${NAMESPACE}',model_name='${MODEL_NAME}',finished_reason=~'error|abort'}[${REQUEST_RATE_INTERVAL}])))"
 					}
 				]
 			},

--- a/internal/controller/serving/reconcilers/kserve_metrics_dashboard_reconciler_test.go
+++ b/internal/controller/serving/reconcilers/kserve_metrics_dashboard_reconciler_test.go
@@ -16,6 +16,7 @@ limitations under the License.
 package reconcilers
 
 import (
+	"encoding/json"
 	"strings"
 
 	kservev1alpha1 "github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
@@ -254,6 +255,73 @@ var _ = Describe("KserveMetricsDashboardReconciler", func() {
 				Expect(configMap.Data["metrics"]).To(ContainSubstring("tgis-model"))
 				Expect(configMap.Data["metrics"]).To(ContainSubstring("test-namespace"))
 			})
+		})
+
+		When("all runtime metrics templates are validated", func() {
+			type metricsQuery struct {
+				Title string `json:"title"`
+				Query string `json:"query"`
+			}
+			type metricsSection struct {
+				Title   string         `json:"title"`
+				Type    string         `json:"type"`
+				Queries []metricsQuery `json:"queries"`
+			}
+			type metricsConfig struct {
+				Config []metricsSection `json:"config"`
+			}
+
+			runtimeData := map[string]string{
+				"Caikit":   constants.CaikitMetricsData,
+				"OVMS":     constants.OvmsMetricsData,
+				"TGIS":     constants.TgisMetricsData,
+				"vLLM":     constants.VllmMetricsData,
+				"NIM":      constants.NIMMetricsData,
+				"MLServer": constants.MLServerMetricsData,
+			}
+
+			for name, data := range runtimeData {
+				It("should have REQUEST_COUNT with success+failed queries for "+name, func() {
+					var cfg metricsConfig
+					Expect(json.Unmarshal([]byte(data), &cfg)).To(Succeed())
+
+					var requestCount *metricsSection
+					for i := range cfg.Config {
+						if cfg.Config[i].Type == "REQUEST_COUNT" {
+							requestCount = &cfg.Config[i]
+							break
+						}
+					}
+					Expect(requestCount).NotTo(BeNil(), name+" must define a REQUEST_COUNT section")
+					Expect(requestCount.Queries).To(HaveLen(2),
+						name+" REQUEST_COUNT must have 2 queries (success + failed)")
+					Expect(strings.ToLower(requestCount.Queries[0].Title)).To(ContainSubstring("successful"),
+						name+" REQUEST_COUNT[0] must be the success query")
+					Expect(strings.ToLower(requestCount.Queries[1].Title)).To(ContainSubstring("failed"),
+						name+" REQUEST_COUNT[1] must be the failed query")
+				})
+
+				It("should not use lowercase variable placeholders for "+name, func() {
+					var cfg metricsConfig
+					Expect(json.Unmarshal([]byte(data), &cfg)).To(Succeed())
+
+					for _, section := range cfg.Config {
+						for _, q := range section.Queries {
+							Expect(q.Query).NotTo(ContainSubstring("${model_name}"),
+								name+" "+section.Type+": must use ${MODEL_NAME}")
+							Expect(q.Query).NotTo(ContainSubstring("${namespace}"),
+								name+" "+section.Type+": must use ${NAMESPACE}")
+						}
+					}
+				})
+
+				It("should have all variables substituted after calling SubstituteVariablesInQueries for "+name, func() {
+					substituted := utils.SubstituteVariablesInQueries(data, "test-ns", "test-model")
+					Expect(substituted).NotTo(ContainSubstring("${"))
+					Expect(substituted).To(ContainSubstring("test-ns"))
+					Expect(substituted).To(ContainSubstring("test-model"))
+				})
+			}
 		})
 
 		When("no valid runtime annotations are set", func() {


### PR DESCRIPTION
Cherry-pick of opendatahub-io/odh-model-controller#806 to downstream `rhoai-3.4`.

The vLLM metrics ConfigMap had two issues causing the "Requests per 5 minutes" metric to not populate in the OpenShift AI dashboard:

1. The success query used `${model_name}` (lowercase) which was not substituted by `SubstituteVariablesInQueries` (expects `${MODEL_NAME}`). This caused the Prometheus query to filter by a literal placeholder string, returning no data.

2. The failed requests query was missing entirely. The dashboard expects two queries at index 0 (success) and index 1 (failed) for the `REQUEST_COUNT` type. The missing query caused the dashboard to send `query=undefined` to Prometheus.

Additionally, the success query now excludes error/abort finish reasons (`finished_reason!~'error|abort'`) so success and failure counts are mutually exclusive.

Adds comprehensive tests validating all runtime metrics templates.

Fixes: RHOAIENG-59920