### PR TITLE
Update vLLM version from 0.18.0 to 0.19.1 in runtime templates

### DIFF
--- a/config/runtimes/vllm-cpu-template.yaml
+++ b/config/runtimes/vllm-cpu-template.yaml
@@ -22,7 +22,7 @@ objects:
       name: vllm-cpu-runtime
       annotations:
         openshift.io/display-name: vLLM CPU (ppc64le/s390x) ServingRuntime for KServe
-        opendatahub.io/runtime-version: 'v0.18.0'
+        opendatahub.io/runtime-version: 'v0.19.1'
       labels:
         opendatahub.io/dashboard: 'true'
     spec:

--- a/config/runtimes/vllm-cpu-x86-template.yaml
+++ b/config/runtimes/vllm-cpu-x86-template.yaml
@@ -22,7 +22,7 @@ objects:
       name: vllm-cpu-x86-runtime
       annotations:
         openshift.io/display-name: vLLM CPU (x86) ServingRuntime for KServe
-        opendatahub.io/runtime-version: 'v0.18.0'
+        opendatahub.io/runtime-version: 'v0.19.1'
       labels:
         opendatahub.io/dashboard: 'true'
     spec:

--- a/config/runtimes/vllm-cuda-template.yaml
+++ b/config/runtimes/vllm-cuda-template.yaml
@@ -23,7 +23,7 @@ objects:
       annotations:
         openshift.io/display-name: vLLM NVIDIA GPU ServingRuntime for KServe
         opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
-        opendatahub.io/runtime-version: 'v0.18.0'
+        opendatahub.io/runtime-version: 'v0.19.1'
       labels:
         opendatahub.io/dashboard: "true"
     spec:

--- a/config/runtimes/vllm-multinode-template.yaml
+++ b/config/runtimes/vllm-multinode-template.yaml
@@ -23,7 +23,7 @@ objects:
       annotations:
         openshift.io/display-name: vLLM Multi-Node ServingRuntime for KServe
         opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
-        opendatahub.io/runtime-version: 'v0.18.0'
+        opendatahub.io/runtime-version: 'v0.19.1'
       labels:
         opendatahub.io/dashboard: 'false'
     spec:

--- a/config/runtimes/vllm-rocm-template.yaml
+++ b/config/runtimes/vllm-rocm-template.yaml
@@ -23,7 +23,7 @@ objects:
       annotations:
         openshift.io/display-name: vLLM AMD GPU ServingRuntime for KServe
         opendatahub.io/recommended-accelerators: '["amd.com/gpu"]'
-        opendatahub.io/runtime-version: 'v0.18.0'
+        opendatahub.io/runtime-version: 'v0.19.1'
       labels:
         opendatahub.io/dashboard: 'true'
     spec:

--- a/config/runtimes/vllm-spyre-ppc64le-template.yaml
+++ b/config/runtimes/vllm-spyre-ppc64le-template.yaml
@@ -23,7 +23,7 @@ objects:
       annotations:
         openshift.io/display-name: vLLM Spyre ppc64le ServingRuntime for KServe
         opendatahub.io/recommended-accelerators: '["ibm.com/spyre_pf"]'
-        opendatahub.io/runtime-version: 'v0.18.0'
+        opendatahub.io/runtime-version: 'v0.19.1'
       labels:
         opendatahub.io/dashboard: 'true'
     spec:

--- a/config/runtimes/vllm-spyre-s390x-template.yaml
+++ b/config/runtimes/vllm-spyre-s390x-template.yaml
@@ -23,7 +23,7 @@ objects:
       annotations:
         openshift.io/display-name: vLLM Spyre s390x ServingRuntime for KServe
         opendatahub.io/recommended-accelerators: '["ibm.com/spyre_vf"]'
-        opendatahub.io/runtime-version: 'v0.18.0'
+        opendatahub.io/runtime-version: 'v0.19.1'
       labels:
         opendatahub.io/dashboard: 'true'
     spec:

--- a/config/runtimes/vllm-spyre-x86-template.yaml
+++ b/config/runtimes/vllm-spyre-x86-template.yaml
@@ -23,7 +23,7 @@ objects:
       annotations:
         openshift.io/display-name: vLLM Spyre on x86 ServingRuntime for KServe
         opendatahub.io/recommended-accelerators: '["ibm.com/spyre_pf"]'
-        opendatahub.io/runtime-version: 'v0.18.0'
+        opendatahub.io/runtime-version: 'v0.19.1'
       labels:
         opendatahub.io/dashboard: 'true'
     spec:


### PR DESCRIPTION
## Summary
Update vLLM runtime version string from 0.18.0 to 0.19.1 across all vLLM runtime templates.

## Reason
The runtime templates were showing incorrect vLLM version in the UI. 
This fix ensures the correct version (0.19.1) is reflected for all vLLM variants.

## Blocker JIRA
https://redhat.atlassian.net/browse/RHOAIENG-63791

## Files Changed
- config/runtimes/vllm-cpu-template.yaml
- config/runtimes/vllm-cpu-x86-template.yaml
- config/runtimes/vllm-cuda-template.yaml
- config/runtimes/vllm-multinode-template.yaml
- config/runtimes/vllm-rocm-template.yaml
- config/runtimes/vllm-spyre-ppc64le-template.yaml
- config/runtimes/vllm-spyre-s390x-template.yaml
- config/runtimes/vllm-spyre-x86-template.yaml