### PR TITLE
feat(ci): add workflow to sync kustomize manifests to kserve

### DIFF
--- a/.github/workflows/sync-manifests-to-kserve.yml
+++ b/.github/workflows/sync-manifests-to-kserve.yml
@@ -24,12 +24,21 @@ jobs:
         with:
           path: odh-model-controller
 
+      - name: Generate token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.RHDS_CI_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RHDS_CI_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: kserve
+
       - name: Checkout kserve
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: ${{ github.repository_owner }}/kserve
           ref: ${{ github.ref_name }}
-          token: ${{ secrets.KSERVE_REPO_WRITE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           path: kserve
 
       - name: Sync manifests
@@ -53,7 +62,7 @@ jobs:
       - name: Create sync PR
         if: steps.changes.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ secrets.KSERVE_REPO_WRITE_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           REPO_OWNER: ${{ github.repository_owner }}
           SOURCE_BRANCH: ${{ github.ref_name }}
           SOURCE_SHA: ${{ github.sha }}

--- a/.github/workflows/sync-manifests-to-kserve.yml
+++ b/.github/workflows/sync-manifests-to-kserve.yml
@@ -1,0 +1,72 @@
+name: Sync Manifests to kserve
+
+on:
+  push:
+    branches: [main]
+    paths: ['config/**']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    name: Sync kustomize manifests to kserve
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout odh-model-controller
+        uses: actions/checkout@v4
+        with:
+          path: odh-model-controller
+
+      - name: Checkout kserve
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.repository_owner }}/kserve
+          ref: ${{ github.ref_name }}
+          token: ${{ secrets.KSERVE_REPO_WRITE_TOKEN }}
+          path: kserve
+
+      - name: Sync manifests
+        run: |
+          DEST="kserve/kserve-module/prefetched-manifests-rhoai/modelcontroller"
+          rm -rf "$DEST"
+          mkdir -p "$DEST"
+          cp -r odh-model-controller/config/. "$DEST/"
+
+      - name: Detect changes
+        id: changes
+        working-directory: kserve
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No manifest changes detected — skipping PR creation."
+          fi
+
+      - name: Create sync PR
+        if: steps.changes.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.KSERVE_REPO_WRITE_TOKEN }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          SOURCE_BRANCH: ${{ github.ref_name }}
+          SOURCE_SHA: ${{ github.sha }}
+        working-directory: kserve
+        run: |
+          SAFE_BRANCH="${SOURCE_BRANCH//\//-}"
+          SYNC_BRANCH="manifests-sync/odh-model-controller-${SAFE_BRANCH}-${SOURCE_SHA:0:8}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$SYNC_BRANCH"
+          git add --all kserve-module/prefetched-manifests-rhoai/modelcontroller/
+          git commit -m "chore: sync odh-model-controller manifests from ${REPO_OWNER}/odh-model-controller@${SOURCE_SHA:0:8}"
+          git push origin "$SYNC_BRANCH"
+
+          gh pr create \
+            --repo "${REPO_OWNER}/kserve" \
+            --base "$SOURCE_BRANCH" \
+            --head "$SYNC_BRANCH" \
+            --title "chore: sync odh-model-controller manifests" \
+            --body "Automated sync of kustomize manifests from [${REPO_OWNER}/odh-model-controller@${SOURCE_SHA}](https://github.com/${REPO_OWNER}/odh-model-controller/commit/${SOURCE_SHA})"

--- a/.github/workflows/sync-manifests-to-kserve.yml
+++ b/.github/workflows/sync-manifests-to-kserve.yml
@@ -14,6 +14,11 @@ jobs:
     name: Sync kustomize manifests to kserve
     runs-on: ubuntu-latest
     steps:
+      - name: Print sync parameters
+        run: |
+          echo "Source: ${{ github.repository }} @ ${{ github.ref_name }}"
+          echo "Target: ${{ github.repository_owner }}/kserve @ ${{ github.ref_name }}"
+
       - name: Checkout odh-model-controller
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Description

Automates the process of syncing the kustomize manifests from `config/` to the
kserve repository. The workflow triggers automatically on pushes to the `main`
branch when manifests change, and also supports manual triggering for any
branch. When changes are detected, it opens a pull request in the kserve
repository targeting the branch with the same name.

Related to https://redhat.atlassian.net/browse/RHOAIENG-68272

## How Has This Been Tested?

Manually with `act`

## Merge criteria:

- [x] JIRA(s) are linked in the PR description
- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
