### PR TITLE
RHOAIENG: Update vLLM version from v0.21.0 to v0.24.0 in runtime template

### DIFF
--- a/config/runtimes/vllm/vllm-cpu-template.yaml
+++ b/config/runtimes/vllm/vllm-cpu-template.yaml
@@ -22,7 +22,7 @@ objects:
       name: vllm-cpu-runtime
       annotations:
         openshift.io/display-name: vLLM CPU (ppc64le/s390x) ServingRuntime for KServe
-        opendatahub.io/runtime-version: 'v0.21.0'
+        opendatahub.io/runtime-version: 'v0.24.0'
       labels:
         opendatahub.io/dashboard: 'true'
     spec:

--- a/config/runtimes/vllm/vllm-cpu-x86-template.yaml
+++ b/config/runtimes/vllm/vllm-cpu-x86-template.yaml
@@ -22,7 +22,7 @@ objects:
       name: vllm-cpu-x86-runtime
       annotations:
         openshift.io/display-name: vLLM CPU (x86) ServingRuntime for KServe
-        opendatahub.io/runtime-version: 'v0.21.0'
+        opendatahub.io/runtime-version: 'v0.24.0'
       labels:
         opendatahub.io/dashboard: 'true'
     spec:

--- a/config/runtimes/vllm/vllm-cuda-template.yaml
+++ b/config/runtimes/vllm/vllm-cuda-template.yaml
@@ -23,7 +23,7 @@ objects:
       annotations:
         openshift.io/display-name: vLLM NVIDIA GPU ServingRuntime for KServe
         opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
-        opendatahub.io/runtime-version: 'v0.21.0'
+        opendatahub.io/runtime-version: 'v0.24.0'
       labels:
         opendatahub.io/dashboard: "true"
     spec:

--- a/config/runtimes/vllm/vllm-gaudi-template.yaml
+++ b/config/runtimes/vllm/vllm-gaudi-template.yaml
@@ -23,7 +23,7 @@ objects:
       annotations:
         openshift.io/display-name: vLLM Intel Gaudi Accelerator ServingRuntime for KServe
         opendatahub.io/recommended-accelerators: '["habana.ai/gaudi"]'
-        opendatahub.io/runtime-version: 'v0.21.0'
+        opendatahub.io/runtime-version: 'v0.24.0'
       labels:
         opendatahub.io/dashboard: 'true'
     spec:

--- a/config/runtimes/vllm/vllm-multinode-template.yaml
+++ b/config/runtimes/vllm/vllm-multinode-template.yaml
@@ -23,7 +23,7 @@ objects:
       annotations:
         openshift.io/display-name: vLLM Multi-Node ServingRuntime for KServe
         opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
-        opendatahub.io/runtime-version: 'v0.21.0'
+        opendatahub.io/runtime-version: 'v0.24.0'
       labels:
         opendatahub.io/dashboard: 'false'
     spec:

--- a/config/runtimes/vllm/vllm-rocm-template.yaml
+++ b/config/runtimes/vllm/vllm-rocm-template.yaml
@@ -23,7 +23,7 @@ objects:
       annotations:
         openshift.io/display-name: vLLM AMD GPU ServingRuntime for KServe
         opendatahub.io/recommended-accelerators: '["amd.com/gpu"]'
-        opendatahub.io/runtime-version: 'v0.21.0'
+        opendatahub.io/runtime-version: 'v0.24.0'
       labels:
         opendatahub.io/dashboard: 'true'
     spec:

--- a/config/runtimes/vllm/vllm-spyre-ppc64le-template.yaml
+++ b/config/runtimes/vllm/vllm-spyre-ppc64le-template.yaml
@@ -23,7 +23,7 @@ objects:
       annotations:
         openshift.io/display-name: vLLM Spyre ppc64le ServingRuntime for KServe
         opendatahub.io/recommended-accelerators: '["ibm.com/spyre_pf"]'
-        opendatahub.io/runtime-version: 'v0.21.0'
+        opendatahub.io/runtime-version: 'v0.24.0'
       labels:
         opendatahub.io/dashboard: 'true'
     spec:

--- a/config/runtimes/vllm/vllm-spyre-s390x-template.yaml
+++ b/config/runtimes/vllm/vllm-spyre-s390x-template.yaml
@@ -23,7 +23,7 @@ objects:
       annotations:
         openshift.io/display-name: vLLM Spyre s390x ServingRuntime for KServe
         opendatahub.io/recommended-accelerators: '["ibm.com/spyre_vf"]'
-        opendatahub.io/runtime-version: 'v0.21.0'
+        opendatahub.io/runtime-version: 'v0.24.0'
       labels:
         opendatahub.io/dashboard: 'true'
     spec:

--- a/config/runtimes/vllm/vllm-spyre-x86-template.yaml
+++ b/config/runtimes/vllm/vllm-spyre-x86-template.yaml
@@ -23,7 +23,7 @@ objects:
       annotations:
         openshift.io/display-name: vLLM Spyre on x86 ServingRuntime for KServe
         opendatahub.io/recommended-accelerators: '["ibm.com/spyre_pf"]'
-        opendatahub.io/runtime-version: 'v0.21.0'
+        opendatahub.io/runtime-version: 'v0.24.0'
       labels:
         opendatahub.io/dashboard: 'true'
     spec:


### PR DESCRIPTION
## Summary

Update vLLM runtime version string from `v0.21.0` to `v0.24.0` across all vLLM runtime templates for RHOAI 3.5 GA.

## Reason

The runtime templates were showing incorrect vLLM version in the UI for all vLLM variants (cuda/cpu/cpu-x86/rocm/spyre/gaudi/multinode). This fix ensures the correct version (`v0.24.0`) is reflected in the UI.

## Blocker JIRA

https://redhat.atlassian.net/browse/RHOAIENG-76963

## Files Changed

- `config/runtimes/vllm/vllm-cpu-template.yaml`
- `config/runtimes/vllm/vllm-cpu-x86-template.yaml`
- `config/runtimes/vllm/vllm-cuda-template.yaml`
- `config/runtimes/vllm/vllm-gaudi-template.yaml`
- `config/runtimes/vllm/vllm-multinode-template.yaml`
- `config/runtimes/vllm/vllm-rocm-template.yaml`
- `config/runtimes/vllm/vllm-spyre-ppc64le-template.yaml`
- `config/runtimes/vllm/vllm-spyre-s390x-template.yaml`
- `config/runtimes/vllm/vllm-spyre-x86-template.yaml`