### PR TITLE
fix: update gatekeeper workflow ref from @gatekeeper to @main

### DIFF
--- a/.github/workflows/post-codefreeze-gatekeeper.yaml
+++ b/.github/workflows/post-codefreeze-gatekeeper.yaml
@@ -8,5 +8,5 @@ on:
 jobs:
   post-codefreeze-gate:
     if: github.event.action != 'labeled' || github.event.label.name == 'run-gatekeeper'
-    uses: red-hat-data-services/devops-shared-resources/.github/workflows/post-codefreeze-gate-logic.yml@gatekeeper
+    uses: red-hat-data-services/devops-shared-resources/.github/workflows/post-codefreeze-gate-logic.yml@main
     secrets: inherit


### PR DESCRIPTION
## Summary

- Adds the thin caller workflow (`.github/workflows/post-codefreeze-gatekeeper.yaml`) that delegates to the central reusable workflow in `devops-shared-resources`
- The gatekeeper runs in **evaluation (advisory-only) mode** -- it posts a PR comment with pass/fail results but does **not** block merges
- Teams can use the `run-gatekeeper` label to manually re-trigger the check

Resolves: [RHOAIENG-82298](https://redhat.atlassian.net/browse/RHOAIENG-82298)