### PR TITLE
Cherrypick: prevent ConfigMap informer cache OOM (RHOAIENG-54558) (#757)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -50,6 +50,7 @@ import (
 	servingcontroller "github.com/opendatahub-io/odh-model-controller/internal/controller/serving"
 	llmcontroller "github.com/opendatahub-io/odh-model-controller/internal/controller/serving/llm"
 	"github.com/opendatahub-io/odh-model-controller/internal/controller/utils"
+	"github.com/opendatahub-io/odh-model-controller/internal/informercache"
 	"github.com/opendatahub-io/odh-model-controller/internal/platform"
 
 	webhookcorev1 "github.com/opendatahub-io/odh-model-controller/internal/webhook/core/v1"
@@ -263,10 +264,24 @@ func createManager(cfg *rest.Config, metricsAddr, probeAddr string,
 		// after the manager stops then its usage might be unsafe.
 		// LeaderElectionReleaseOnCancel: true,
 		Client: client.Options{
-			Cache: &client.CacheOptions{},
+			Cache: &client.CacheOptions{
+				// ConfigMap client reads bypass the cache since the informer
+				// stores metadata-only objects (no .data/.binaryData).
+				DisableFor: []client.Object{
+					&corev1.ConfigMap{},
+				},
+			},
 		},
 		Cache: cache.Options{
+			DefaultTransform: cache.TransformStripManagedFields(),
 			ByObject: map[client.Object]cache.ByObject{
+				// Strip ConfigMap data from the informer cache to prevent OOM
+				// from cluster-wide caching while still delivering watch events
+				// for external ConfigMaps (CA bundles, etc.). Payload reads use
+				// direct API calls via DisableFor above.
+				&corev1.ConfigMap{}: {
+					Transform: informercache.StripConfigMapData,
+				},
 				&corev1.Secret{}: {
 					Label: labels.SelectorFromSet(labels.Set{
 						"opendatahub.io/managed": "true",

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -72,6 +72,9 @@ spec:
             drop:
             - "ALL"
         env:
+          # Soft GC limit at ~88% of the 2Gi container limit (matches other RHOAI operators).
+          - name: GOMEMLIMIT
+            value: 1800MiB
           - name: POD_NAMESPACE
             valueFrom:
               fieldRef:

--- a/internal/controller/core/suite_test.go
+++ b/internal/controller/core/suite_test.go
@@ -48,6 +48,7 @@ import (
 	// +kubebuilder:scaffold:imports
 
 	"github.com/opendatahub-io/odh-model-controller/internal/controller/utils"
+	"github.com/opendatahub-io/odh-model-controller/internal/informercache"
 	testutils "github.com/opendatahub-io/odh-model-controller/test/utils"
 )
 
@@ -128,10 +129,18 @@ var _ = BeforeSuite(func() {
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme.Scheme,
 		Client: client.Options{
-			Cache: &client.CacheOptions{},
+			Cache: &client.CacheOptions{
+				DisableFor: []client.Object{
+					&corev1.ConfigMap{},
+				},
+			},
 		},
 		Cache: cache.Options{
+			DefaultTransform: cache.TransformStripManagedFields(),
 			ByObject: map[client.Object]cache.ByObject{
+				&corev1.ConfigMap{}: {
+					Transform: informercache.StripConfigMapData,
+				},
 				&corev1.Secret{}: {
 					Label: labels.SelectorFromSet(labels.Set{
 						"opendatahub.io/managed": "true",

--- a/internal/controller/serving/llm/gateway_controller.go
+++ b/internal/controller/serving/llm/gateway_controller.go
@@ -1072,9 +1072,11 @@ func (r *GatewayReconciler) SetupWithManager(mgr ctrl.Manager, setupLog logr.Log
 					if podNS := os.Getenv("POD_NAMESPACE"); podNS != "" && e.ObjectNew.GetNamespace() != podNS {
 						return false
 					}
-					oldCM := e.ObjectOld.(*corev1.ConfigMap)
-					newCM := e.ObjectNew.(*corev1.ConfigMap)
-					return oldCM.Data["ingress"] != newCM.Data["ingress"]
+					// ConfigMaps have no spec/status split so metadata.generation
+					// is never incremented. Return true to reconcile on any update
+					// to this ConfigMap; the name/namespace guards above are
+					// sufficient to keep the trigger narrow.
+					return true
 				},
 				DeleteFunc: func(_ event.DeleteEvent) bool {
 					return false

--- a/internal/controller/serving/suite_test.go
+++ b/internal/controller/serving/suite_test.go
@@ -47,6 +47,7 @@ import (
 	// +kubebuilder:scaffold:imports
 
 	"github.com/opendatahub-io/odh-model-controller/internal/controller/utils"
+	"github.com/opendatahub-io/odh-model-controller/internal/informercache"
 	testutils "github.com/opendatahub-io/odh-model-controller/test/utils"
 )
 
@@ -116,10 +117,18 @@ var _ = BeforeSuite(func() {
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme.Scheme,
 		Client: client.Options{
-			Cache: &client.CacheOptions{},
+			Cache: &client.CacheOptions{
+				DisableFor: []client.Object{
+					&corev1.ConfigMap{},
+				},
+			},
 		},
 		Cache: cache.Options{
+			DefaultTransform: cache.TransformStripManagedFields(),
 			ByObject: map[client.Object]cache.ByObject{
+				&corev1.ConfigMap{}: {
+					Transform: informercache.StripConfigMapData,
+				},
 				&corev1.Secret{}: {
 					Label: k8sLabels.SelectorFromSet(k8sLabels.Set{
 						"opendatahub.io/managed": "true",

--- a/internal/informercache/strip.go
+++ b/internal/informercache/strip.go
@@ -1,0 +1,16 @@
+package informercache
+
+import corev1 "k8s.io/api/core/v1"
+
+// StripConfigMapData removes data payloads from cached ConfigMaps to reduce
+// memory consumption. Watch events still trigger reconciliation; actual data
+// is read via direct API calls (DisableFor).
+func StripConfigMapData(i interface{}) (interface{}, error) {
+	if cm, ok := i.(*corev1.ConfigMap); ok {
+		cm.Data = nil
+		cm.BinaryData = nil
+		cm.Annotations = nil
+		cm.SetManagedFields(nil)
+	}
+	return i, nil
+}

--- a/internal/informercache/strip_test.go
+++ b/internal/informercache/strip_test.go
@@ -1,0 +1,65 @@
+package informercache
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestStripConfigMapData(t *testing.T) {
+	t.Run("strips data payloads and annotations", func(t *testing.T) {
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-cm",
+				Namespace: "test-ns",
+				Annotations: map[string]string{
+					"example.com/large": "payload",
+				},
+				ManagedFields: []metav1.ManagedFieldsEntry{{Manager: "kubectl"}},
+			},
+			Data: map[string]string{
+				"key": "value",
+			},
+			BinaryData: map[string][]byte{
+				"bin": []byte("data"),
+			},
+		}
+
+		out, err := StripConfigMapData(cm)
+		if err != nil {
+			t.Fatalf("StripConfigMapData() error = %v", err)
+		}
+
+		stripped, ok := out.(*corev1.ConfigMap)
+		if !ok {
+			t.Fatalf("StripConfigMapData() returned %T, want *corev1.ConfigMap", out)
+		}
+		if stripped.Data != nil {
+			t.Fatal("expected Data to be nil")
+		}
+		if stripped.BinaryData != nil {
+			t.Fatal("expected BinaryData to be nil")
+		}
+		if stripped.Annotations != nil {
+			t.Fatal("expected Annotations to be nil")
+		}
+		if stripped.GetManagedFields() != nil {
+			t.Fatal("expected ManagedFields to be nil")
+		}
+		if stripped.Name != "test-cm" || stripped.Namespace != "test-ns" {
+			t.Fatalf("metadata preserved: got %s/%s", stripped.Namespace, stripped.Name)
+		}
+	})
+
+	t.Run("passes through non-ConfigMap objects", func(t *testing.T) {
+		secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "s"}}
+		out, err := StripConfigMapData(secret)
+		if err != nil {
+			t.Fatalf("StripConfigMapData() error = %v", err)
+		}
+		if out != secret {
+			t.Fatal("expected original object to be returned unchanged")
+		}
+	})
+}


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Cherrypick: prevent ConfigMap informer cache OOM 

fix: https://redhat.atlassian.net/browse/RHOAIENG-85209

Strip ConfigMap data from the informer cache and bypass the cache for ConfigMap client reads so cluster-wide watch events still work without retaining large payloads in memory. Keep the existing Secret label selector, add gateway predicate fix for stripped ConfigMaps, set GOMEMLIMIT=1800MiB, and add strip transform tests.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] JIRA(s) are linked in the PR description
- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work