### PR TITLE
[RHOAIENG-74045] - upgrade golang to 1.26

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25@sha256:8c5aeac74b4b60dc2e5e44f6b639186b7ec2fec8f0eb9a36d4a32dcf8e255f52 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Containerfile.server
+++ b/Containerfile.server
@@ -1,5 +1,5 @@
 # Build the model-serving-api binary
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25@sha256:8c5aeac74b4b60dc2e5e44f6b639186b7ec2fec8f0eb9a36d4a32dcf8e255f52 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26 AS builder
 
 # These built-in args are defined in the global scope, and are not automatically
 # accessible within build stages or RUN commands.

--- a/Containerfile.server.konflux
+++ b/Containerfile.server.konflux
@@ -1,5 +1,5 @@
 # Build the model-serving-api binary
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25@sha256:8c5aeac74b4b60dc2e5e44f6b639186b7ec2fec8f0eb9a36d4a32dcf8e255f52 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26 AS builder
 
 # These built-in args are defined in the global scope, and are not automatically
 # accessible within build stages or RUN commands.

--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -3,7 +3,7 @@ ARG SOURCE_CODE=.
 
 # Build the manager binary
 
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25@sha256:90a36bc2013b3fcb28e2a4b082c9b895d7c2c679e58b95aed9721970f3339d0e as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26 as builder
 
 # These built-in args are defined in the global scope, and are not automatically accessible within build stages or RUN commands.
 # To expose these arguments inside the build stage, we need to redefine it without a value.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/opendatahub-io/odh-model-controller
 
-go 1.25.8
+go 1.26.5
 
 require (
 	github.com/fsnotify/fsnotify v1.9.0


### PR DESCRIPTION
chore: Upgrade golang to 1.26 to address CVE-2026-33811: Go net package: Denial of Service via long CNAME response in LookupCNAME

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] JIRA(s) are linked in the PR description
- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work