### PR TITLE
[RHOAIENG-87954] Copy pkg/ in Dockerfile.konflux

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -22,6 +22,7 @@ RUN go mod download
 COPY cmd/main.go cmd/main.go
 COPY api/ api/
 COPY internal/ internal/
+COPY pkg/ pkg/
 
 # Build
 USER root


### PR DESCRIPTION
## Description
`Dockerfile.konflux` used an explicit whitelist `COPY` (`cmd/main.go`, `api/`, `internal/`) and never copied `pkg/`. Since #863 (SecureServing / TLS profile watcher / cert provisioning) `cmd/main.go` imports `pkg/tls`, so the konflux `strictfipsruntime` build failed:

```
cmd/main.go:49:2: no required module provides package github.com/opendatahub-io/odh-model-controller/pkg/tls
```

The ODH `Containerfile` already has `COPY pkg/ pkg/`; the downstream konflux build file had drifted. This adds the missing line.

## How Has This Been Tested?
`pkg/` is now in the build context. Konflux build should resolve `pkg/tls` and compile. Verify via the konflux pipeline on this PR.

## Merge criteria:
- [x] JIRA(s) are linked in the PR description
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

JIRA: https://issues.redhat.com/browse/RHOAIENG-87954

Involved repo: https://github.com/red-hat-data-services/odh-model-controller
