### PR TITLE
Add vLLM-Omni CUDA ServingRuntime template for multimodal inference (Tech Preview) (#906)

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -216,6 +216,7 @@ Pre-built ServingRuntime templates for supported model servers live in `config/r
 | `vllm-gaudi-template.yaml` | vLLM (Intel Gaudi) |
 | `vllm-spyre-*.yaml` | vLLM (IBM Spyre accelerator) |
 | `vllm-multinode-template.yaml` | vLLM multi-node (Ray) |
+| `vllm-omni-cuda-template.yaml` | vLLM-Omni (NVIDIA GPU, multimodal) |
 | `ovms-kserve-template.yaml` | OpenVINO Model Server |
 | `mlserver-template.yaml` | Seldon MLServer |
 | `mlserver-cuda-template.yaml` | Seldon MLServer (NVIDIA GPU) |

--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -358,6 +358,39 @@ replacements:
       kind: ConfigMap
       version: v1
       name: odh-model-controller-parameters
+      fieldPath: data.vllm-omni-cuda-image
+    targets:
+      - select:
+          kind: Template
+          name: vllm-omni-cuda-runtime-template
+        fieldPaths:
+          - objects.0.spec.containers.0.image
+  - source:
+      kind: ConfigMap
+      version: v1
+      name: odh-model-controller-parameters
+      fieldPath: data.vllm-omni-cuda-image-fast-1
+    targets:
+      - select:
+          kind: Template
+          name: vllm-omni-cuda-runtime-template-fast-1
+        fieldPaths:
+          - objects.0.spec.containers.0.image
+  - source:
+      kind: ConfigMap
+      version: v1
+      name: odh-model-controller-parameters
+      fieldPath: data.vllm-omni-cuda-image-fast-2
+    targets:
+      - select:
+          kind: Template
+          name: vllm-omni-cuda-runtime-template-fast-2
+        fieldPaths:
+          - objects.0.spec.containers.0.image
+  - source:
+      kind: ConfigMap
+      version: v1
+      name: odh-model-controller-parameters
       fieldPath: data.odh-model-controller
     targets:
       - select:

--- a/config/base/params.env
+++ b/config/base/params.env
@@ -30,4 +30,7 @@ vllm-rocm-image-fast-2=quay.io/vllm/vllm-rocm:latest
 vllm-spyre-image=quay.io/vllm/vllm:latest
 vllm-spyre-image-fast-1=quay.io/vllm/vllm:latest
 vllm-spyre-image-fast-2=quay.io/vllm/vllm:latest
+vllm-omni-cuda-image=quay.io/vllm-omni/vllm-omni-cuda:latest
+vllm-omni-cuda-image-fast-1=quay.io/vllm-omni/vllm-omni-cuda:latest
+vllm-omni-cuda-image-fast-2=quay.io/vllm-omni/vllm-omni-cuda:latest
 guardrails-detector-huggingface-runtime-image=quay.io/trustyai/guardrails-detector-huggingface-runtime:latest

--- a/config/component_metadata.yaml
+++ b/config/component_metadata.yaml
@@ -1,4 +1,7 @@
 releases:
+  - name: vLLM-Omni
+    version: v0.26.0
+    repoUrl: https://github.com/vllm-project/vllm-omni
   - name: OpenVINO Model Server
     version: v2025.4
     repoUrl: https://github.com/openvinotoolkit/model_server

--- a/config/runtimes-fast-1/kustomization.yaml
+++ b/config/runtimes-fast-1/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 
 resources:
   - ../runtimes/vllm
+  - ../runtimes/vllm-omni
 
 nameSuffix: -fast-1
 
@@ -67,3 +68,8 @@ patches:
       - op: replace
         path: /objects/0/metadata/name
         value: vllm-cpu-x86-runtime-fast-1
+  - target: { kind: Template, name: vllm-omni-cuda-runtime-template }
+    patch: |-
+      - op: replace
+        path: /objects/0/metadata/name
+        value: vllm-omni-cuda-runtime-fast-1

--- a/config/runtimes-fast-2/kustomization.yaml
+++ b/config/runtimes-fast-2/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 
 resources:
   - ../runtimes/vllm
+  - ../runtimes/vllm-omni
 
 nameSuffix: -fast-2
 
@@ -67,3 +68,8 @@ patches:
       - op: replace
         path: /objects/0/metadata/name
         value: vllm-cpu-x86-runtime-fast-2
+  - target: { kind: Template, name: vllm-omni-cuda-runtime-template }
+    patch: |-
+      - op: replace
+        path: /objects/0/metadata/name
+        value: vllm-omni-cuda-runtime-fast-2

--- a/config/runtimes/kustomization.yaml
+++ b/config/runtimes/kustomization.yaml
@@ -10,5 +10,6 @@ resources:
   - mlserver-template.yaml
   - mlserver-cuda-template.yaml
   - vllm/
+  - vllm-omni/
   - hf-detector-template.yaml
   - autogluon-template.yaml

--- a/config/runtimes/vllm-omni/kustomization.yaml
+++ b/config/runtimes/vllm-omni/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - vllm-omni-cuda-template.yaml

--- a/config/runtimes/vllm-omni/vllm-omni-cuda-template.yaml
+++ b/config/runtimes/vllm-omni/vllm-omni-cuda-template.yaml
@@ -1,0 +1,83 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  labels:
+    opendatahub.io/dashboard: 'true'
+    opendatahub.io/ootb: 'true'
+  annotations:
+    description: vLLM-Omni ServingRuntime with CUDA support for multimodal inference (audio, vision, diffusion) on NVIDIA GPUs
+    openshift.io/display-name: vLLM-Omni NVIDIA GPU ServingRuntime for KServe - Tech Preview
+    openshift.io/provider-display-name: Red Hat, Inc.
+    tags: rhods,rhoai,kserve,servingruntime
+    template.openshift.io/documentation-url: https://github.com/vllm-project/vllm-omni
+    template.openshift.io/long-description: This template defines resources needed to deploy vLLM-Omni NVIDIA GPU ServingRuntime with KServe in Red Hat OpenShift AI for multimodal inference including omni, diffusion, and TTS models (Tech Preview)
+    opendatahub.io/modelServingSupport: '["single"]'
+    opendatahub.io/apiProtocol: 'REST'
+    opendatahub.io/model-type: '["generative"]'
+    opendatahub.io/support-status: "unsupported"
+  name: vllm-omni-cuda-runtime-template
+objects:
+  - apiVersion: serving.kserve.io/v1alpha1
+    kind: ServingRuntime
+    metadata:
+      name: vllm-omni-cuda-runtime
+      annotations:
+        openshift.io/display-name: vLLM-Omni NVIDIA GPU ServingRuntime for KServe - Tech Preview
+        opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
+        opendatahub.io/runtime-version: 'v0.26.0'
+        opendatahub.io/support-status: "unsupported"
+      labels:
+        opendatahub.io/dashboard: 'true'
+    spec:
+      annotations:
+        opendatahub.io/kserve-runtime: 'vllm-omni'
+        prometheus.io/port: '8080'
+        prometheus.io/path: '/metrics'
+        monitoring.opendatahub.io/scrape: 'true'
+      multiModel: false
+      supportedModelFormats:
+        - autoSelect: false
+          name: vLLM
+      containers:
+        - name: kserve-container
+          image: $(vllm-omni-cuda-image)
+          command:
+            - vllm
+            - serve
+          args:
+            - "--port=8080"
+            - "--model=/mnt/models"
+            - "--omni"
+            - "--log-stats"
+            - "--served-model-name={{.Name}}"
+          env:
+            - name: HF_HOME
+              value: /tmp/hf_home
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            failureThreshold: 40
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            periodSeconds: 15
+            failureThreshold: 3
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL

--- a/internal/controller/constants/constants.go
+++ b/internal/controller/constants/constants.go
@@ -107,6 +107,7 @@ const (
 	OvmsRuntimeName         = "ovms"
 	TgisRuntimeName         = "tgis"
 	VllmRuntimeName         = "vllm"
+	VllmOmniRuntimeName     = "vllm-omni"
 	MLServerRuntimeName     = "mlserver"
 	AutogluonRuntimeName    = "autogluon"
 )

--- a/internal/controller/constants/runtime-metrics.go
+++ b/internal/controller/constants/runtime-metrics.go
@@ -228,6 +228,89 @@ const (
 		]
     }`
 
+	VllmOmniMetricsData = `{
+        "config": [
+			{
+				"title": "Requests per 5 minutes",
+				"type": "REQUEST_COUNT",
+				"queries": [
+					{
+						"title": "Number of successful incoming requests",
+						"query": "round(sum(increase(vllm:omni_requests_success_total{namespace='${NAMESPACE}',model_name='${MODEL_NAME}',finished_reason!~'error|abort'}[${REQUEST_RATE_INTERVAL}])))"
+					},
+					{
+						"title": "Number of failed incoming requests",
+						"query": "round(sum(increase(vllm:omni_requests_success_total{namespace='${NAMESPACE}',model_name='${MODEL_NAME}',finished_reason=~'error|abort'}[${REQUEST_RATE_INTERVAL}])))"
+					}
+				]
+			},
+			{
+				"title": "Average response time (ms)",
+				"type": "MEAN_LATENCY",
+				"queries": [
+					{
+						"title": "Average pipeline e2e latency",
+						"query": "histogram_quantile(0.5, sum(rate(vllm:omni_e2e_request_latency_s_bucket{namespace='${NAMESPACE}', model_name='${MODEL_NAME}'}[${RATE_INTERVAL}])) by (le))"
+					}
+				]
+			},
+			{
+				"title": "Time to first audio packet",
+				"type": "TIME_TO_FIRST_TOKEN",
+				"queries": [
+					{
+						"title": "Audio TTFP (p95)",
+						"query": "histogram_quantile(0.95, sum(rate(vllm:omni_audio_ttfp_s_bucket{namespace='${NAMESPACE}', model_name='${MODEL_NAME}'}[${RATE_INTERVAL}])) by (le))"
+					}
+				]
+			},
+			{
+				"title": "Current running and waiting requests",
+				"type": "CURRENT_REQUESTS",
+				"queries": [
+					{
+						"title": "Requests waiting",
+						"query": "vllm:omni_num_requests_waiting{namespace='${NAMESPACE}', model_name='${MODEL_NAME}'}"
+					},
+					{
+						"title": "Requests running",
+						"query": "vllm:omni_num_requests_running{namespace='${NAMESPACE}', model_name='${MODEL_NAME}'}"
+					}
+				]
+			},
+			{
+				"title": "GPU cache usage over time",
+				"type": "KV_CACHE",
+				"queries": [
+					{
+						"title": "KV cache usage per stage",
+						"query": "sum(vllm:gpu_cache_usage_perc{namespace='${NAMESPACE}', pod=~'${MODEL_NAME}-predictor-.*'}) by (stage)"
+					}
+				]
+			},
+			{
+				"title": "CPU utilization %",
+				"type": "CPU_USAGE",
+				"queries": [
+					{
+						"title": "CPU usage",
+						"query": "sum(pod:container_cpu_usage:sum{namespace='${NAMESPACE}', pod=~'${MODEL_NAME}-predictor-.*'})/sum(kube_pod_resource_limit{resource='cpu', pod=~'${MODEL_NAME}-predictor-.*', namespace='${NAMESPACE}'})"
+					}
+				]
+			},
+			{
+				"title": "Memory utilization %",
+				"type": "MEMORY_USAGE",
+				"queries": [
+					{
+						"title": "Memory usage",
+						"query": "sum(container_memory_working_set_bytes{namespace='${NAMESPACE}', pod=~'${MODEL_NAME}-predictor-.*'})/sum(kube_pod_resource_limit{resource='memory', pod=~'${MODEL_NAME}-predictor-.*', namespace='${NAMESPACE}'})"
+					}
+				]
+			}
+		]
+    }`
+
 	// NVIDIA NIM
 	NIMMetricsData = `{
         "config": [

--- a/internal/controller/serving/reconcilers/kserve_metrics_dashboard_reconciler.go
+++ b/internal/controller/serving/reconcilers/kserve_metrics_dashboard_reconciler.go
@@ -200,6 +200,7 @@ func (r *KserveMetricsDashboardReconciler) processDelta(ctx context.Context, log
 //   - IsNimRuntimeAnnotation: Returns NIMMetricsData if set to "true"
 //   - KServeRuntimeAnnotation with OvmsRuntimeName: Returns OvmsMetricsData
 //   - KServeRuntimeAnnotation with VllmRuntimeName: Returns VllmMetricsData
+//   - KServeRuntimeAnnotation with VllmOmniRuntimeName: Returns VllmOmniMetricsData
 //   - KServeRuntimeAnnotation with TgisRuntimeName: Returns TgisMetricsData
 //   - KServeRuntimeAnnotation with MLServerRuntimeName: Returns MLServerMetricsData
 //   - KServeRuntimeAnnotation with AutogluonRuntimeName: Returns AutogluonMetricsData
@@ -225,6 +226,8 @@ func getMetricsData(runtime *kservev1alpha1.ServingRuntime) (string, bool) {
 		return constants.OvmsMetricsData, true
 	case runtime.Spec.Annotations[constants.KServeRuntimeAnnotation] == constants.VllmRuntimeName:
 		return constants.VllmMetricsData, true
+	case runtime.Spec.Annotations[constants.KServeRuntimeAnnotation] == constants.VllmOmniRuntimeName:
+		return constants.VllmOmniMetricsData, true
 	case runtime.Spec.Annotations[constants.KServeRuntimeAnnotation] == constants.TgisRuntimeName:
 		return constants.TgisMetricsData, true
 	case runtime.Spec.Annotations[constants.KServeRuntimeAnnotation] == constants.MLServerRuntimeName:

--- a/internal/controller/serving/reconcilers/kserve_metrics_dashboard_reconciler_test.go
+++ b/internal/controller/serving/reconcilers/kserve_metrics_dashboard_reconciler_test.go
@@ -217,6 +217,55 @@ var _ = Describe("KserveMetricsDashboardReconciler", func() {
 			})
 		})
 
+		When("vLLM-Omni CUDA Runtime is used", func() {
+			It("should create ConfigMap with supported=true and vLLM-Omni metrics", func(ctx SpecContext) {
+				servingRuntime := createServingRuntime("vllm-omni-cuda-runtime", map[string]string{
+					constants.KServeRuntimeAnnotation: constants.VllmOmniRuntimeName,
+				})
+
+				isvc := &kservev1beta1.InferenceService{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "vllm-omni-cuda-model",
+						Namespace: "test-namespace",
+					},
+					Spec: kservev1beta1.InferenceServiceSpec{
+						Predictor: kservev1beta1.PredictorSpec{
+							Model: &kservev1beta1.ModelSpec{
+								ModelFormat: kservev1beta1.ModelFormat{Name: "huggingface"},
+								Runtime:     ptr.To("vllm-omni-cuda-runtime"),
+							},
+						},
+					},
+				}
+
+				client := fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(isvc, servingRuntime).
+					Build()
+				reconciler := NewKserveMetricsDashboardReconciler(client)
+
+				err := reconciler.Reconcile(ctx, log.Log, isvc)
+				Expect(err).NotTo(HaveOccurred())
+
+				configMap := &corev1.ConfigMap{}
+				err = client.Get(ctx, k8stypes.NamespacedName{
+					Name:      isvc.Name + constants.KserveMetricsConfigMapNameSuffix,
+					Namespace: isvc.Namespace,
+				}, configMap)
+				Expect(err).NotTo(HaveOccurred())
+
+				fromGetMetrics, _ := getMetricsData(servingRuntime)
+				finaldata := utils.SubstituteVariablesInQueries(constants.VllmOmniMetricsData, isvc.Namespace, isvc.Name)
+
+				Expect(configMap.Data["supported"]).To(Equal("true"))
+				Expect(configMap.Data["metrics"]).To(Equal(finaldata))
+				Expect(fromGetMetrics).To(Equal(constants.VllmOmniMetricsData))
+				Expect(configMap.Data["metrics"]).To(ContainSubstring("vllm:omni_"))
+				Expect(configMap.Data["metrics"]).To(ContainSubstring("vllm-omni-cuda-model"))
+				Expect(configMap.Data["metrics"]).To(ContainSubstring("test-namespace"))
+			})
+		})
+
 		When("TGIS Runtime is used", func() {
 			It("should create ConfigMap with supported=true and TGIS metrics", func(ctx SpecContext) {
 				// Create TGIS ServingRuntime
@@ -321,12 +370,13 @@ var _ = Describe("KserveMetricsDashboardReconciler", func() {
 
 		When("all runtime metrics templates are validated", func() {
 			runtimeData := map[string]string{
-				"Caikit":   constants.CaikitMetricsData,
-				"OVMS":     constants.OvmsMetricsData,
-				"TGIS":     constants.TgisMetricsData,
-				"vLLM":     constants.VllmMetricsData,
-				"NIM":      constants.NIMMetricsData,
-				"MLServer": constants.MLServerMetricsData,
+				"Caikit":    constants.CaikitMetricsData,
+				"OVMS":      constants.OvmsMetricsData,
+				"TGIS":      constants.TgisMetricsData,
+				"vLLM":      constants.VllmMetricsData,
+				"vLLM-Omni": constants.VllmOmniMetricsData,
+				"NIM":       constants.NIMMetricsData,
+				"MLServer":  constants.MLServerMetricsData,
 			}
 
 			for name, data := range runtimeData {


### PR DESCRIPTION
Add vLLM-Omni CUDA ServingRuntime template for multimodal inference (Tech Preview) (#906)

Signed-off-by: Syed Nomaan Ali <syedali@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds vLLM-Omni CUDA ServingRuntime template for multimodal inference (TTS, omni-voice, diffusion) on NVIDIA GPUs. vLLM-Omni is a distinct runtime from standard vLLM with multi-stage pipelines for audio/vision modalities.

### Changes:
- New template in config/runtimes/vllm-omni/ with probes (upstream Helm chart aligned), --omni, --log-stats, security context
- Dedicated VllmOmniMetricsData with omni-specific Prometheus queries (vllm:omni_* families)
- VllmOmniRuntimeName constant + metrics reconciler routing
- resolveRuntimeName helper (status fallback for auto-selected ISVCs)
- Fast channel: stable + fast-1 + fast-2 all enabled (operator filter handles rotation)
- Unit tests + structural validation

### Relates to: [RHAISTRAT-2493](https://issues.redhat.com/browse/RHAISTRAT-2493), [RHOAIENG-78709](https://issues.redhat.com/browse/RHOAIENG-78709), [RHOAIENG-78710](https://redhat.atlassian.net/browse/RHOAIENG-78710)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] JIRA(s) are linked in the PR description
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work